### PR TITLE
Added support for creating autopkg files

### DIFF
--- a/CMakeLists.pack.autopkg.cmake
+++ b/CMakeLists.pack.autopkg.cmake
@@ -1,0 +1,4 @@
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/NuGetTools.cmake")
+
+nuget_merge_autopkg_files(OUTPUT "${MERGE_OUTPUT}" INPUTS ${MERGE_INPUTS})
+nuget_pack_autopkg(AUTOPKG_FILEPATH "${MERGE_OUTPUT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,45 @@ add_test(NAME write_nuspec_simple.mergeandpack
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_nuspec_simple"
 )
 
+# Test: write_autopkg_simple
+# TODO: we rely on sequential execution here...
+add_custom_target(write_autopkg_simple.mkdir ALL
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.g
+    COMMAND "${CMAKE_COMMAND}" -T v142,host=x64 -G "Visual Studio 15 2017 Win64" -DNUGET_COMMAND=nuget
+        "-DNUGET_PACKAGES_DIR=${CMAKE_SOURCE_DIR}/packages" "-DCMAKE_CONFIGURATION_TYPES=Release;Debug"
+        "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/install/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+        "${CMAKE_SOURCE_DIR}/tests/write_autopkg_simple"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.release.build
+    COMMAND "${CMAKE_COMMAND}" --build . --config Release --target ALL_BUILD -- /p:PlatformToolset=v141 /p:Configuration=Release /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.debug.build
+    COMMAND "${CMAKE_COMMAND}" --build . --config Debug --target ALL_BUILD -- /p:PlatformToolset=v141 /p:Configuration=Debug /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_custom_target(write_autopkg_simple.install.mkdir ALL
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/install/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.release.install
+    COMMAND "${CMAKE_COMMAND}" --build . --config Release --target INSTALL -- /p:PlatformToolset=v141 /p:Configuration=Release /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.debug.install
+    COMMAND "${CMAKE_COMMAND}" --build . --config Debug --target INSTALL -- /p:PlatformToolset=v141 /p:Configuration=Debug /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+add_test(NAME write_autopkg_simple.mergeandpack
+    COMMAND "${CMAKE_COMMAND}"
+        "-DMERGE_OUTPUT=CMakeNuGetTools/write_autopkg_simple.autopkg"
+        "-DMERGE_INPUTS=CMakeNuGetTools/write_autopkg_simple.Release.autopkg;CMakeNuGetTools/write_autopkg_simple.Debug.autopkg"
+        -P "${CMAKE_SOURCE_DIR}/CMakeLists.pack.autopkg.cmake"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_simple"
+)
+
 # Test: export_simple_toolchain
 # TODO: we rely on sequential execution here...
 add_custom_target(export_simple_toolchain.mkdir ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,45 @@ add_test(NAME write_nuspec_simple.mergeandpack
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_nuspec_simple"
 )
 
+# Test: write_autopkg_nested
+# TODO: we rely on sequential execution here...
+add_custom_target(write_autopkg_nested.mkdir ALL
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.g
+    COMMAND "${CMAKE_COMMAND}" -T v142,host=x64 -G "Visual Studio 15 2017 Win64" -DNUGET_COMMAND=nuget
+        "-DNUGET_PACKAGES_DIR=${CMAKE_SOURCE_DIR}/packages" "-DCMAKE_CONFIGURATION_TYPES=Release;Debug"
+        "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/install/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+        "${CMAKE_SOURCE_DIR}/tests/write_autopkg_nested"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.release.build
+    COMMAND "${CMAKE_COMMAND}" --build . --config Release --target ALL_BUILD -- /p:PlatformToolset=v141 /p:Configuration=Release /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.debug.build
+    COMMAND "${CMAKE_COMMAND}" --build . --config Debug --target ALL_BUILD -- /p:PlatformToolset=v141 /p:Configuration=Debug /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_custom_target(write_autopkg_nested.install.mkdir ALL
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/install/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.release.install
+    COMMAND "${CMAKE_COMMAND}" --build . --config Release --target INSTALL -- /p:PlatformToolset=v141 /p:Configuration=Release /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.debug.install
+    COMMAND "${CMAKE_COMMAND}" --build . --config Debug --target INSTALL -- /p:PlatformToolset=v141 /p:Configuration=Debug /p:Platform=x64
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+add_test(NAME write_autopkg_nested.mergeandpack
+    COMMAND "${CMAKE_COMMAND}"
+        "-DMERGE_OUTPUT=CMakeNuGetTools/write_autopkg_nested.autopkg"
+        "-DMERGE_INPUTS=CMakeNuGetTools/write_autopkg_nested.Release.autopkg;CMakeNuGetTools/write_autopkg_nested.Debug.autopkg"
+        -P "${CMAKE_SOURCE_DIR}/CMakeLists.pack.autopkg.cmake"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/build/cmake/x64-windows/MultiConfig/write_autopkg_nested"
+)
+
 # Test: write_autopkg_simple
 # TODO: we rely on sequential execution here...
 add_custom_target(write_autopkg_simple.mkdir ALL

--- a/ChangeGeneratorToVS2017.ps1
+++ b/ChangeGeneratorToVS2017.ps1
@@ -1,0 +1,27 @@
+function Update-CMakeFile() {
+	param([string] $fileName)
+
+    (Get-Content $fileName) | 
+        ForEach-Object{$_ -replace '-G "Visual Studio 16 2019" -A x64','-G "Visual Studio 15 2017 Win64"'} |
+            Set-Content $fileName
+}
+
+function Update-JsonFile() {
+	param([string] $fileName)
+
+    $text = [string]::Join("`r`n", (Get-Content $fileName))
+    [regex]::Replace($text, 
+                     """generator"": ""Visual Studio 16 2019"",`r`n            ""architecture"": ""x64"",",
+                     """generator"": ""Visual Studio 15 2017 Win64"",",
+                     "SingleLine") |
+        Set-Content $fileName -NoNewline
+}
+
+Update-CMakeFile .\build.cmake
+Update-CMakeFile .\CMakeLists.txt
+Update-JsonFile .\tests\export_cmake_and_install\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_cmake\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_dot_targets\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_toolchain\CMakeSettings.json
+Update-JsonFile .\tests\write_autopkg_simple\CMakeSettings.json
+Update-JsonFile .\tests\write_nuspec_simple\CMakeSettings.json

--- a/ChangeGeneratorToVS2017.ps1
+++ b/ChangeGeneratorToVS2017.ps1
@@ -23,5 +23,6 @@ Update-JsonFile .\tests\export_cmake_and_install\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_cmake\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_dot_targets\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_toolchain\CMakeSettings.json
+Update-JsonFile .\tests\write_autopkg_nested\CMakeSettings.json
 Update-JsonFile .\tests\write_autopkg_simple\CMakeSettings.json
 Update-JsonFile .\tests\write_nuspec_simple\CMakeSettings.json

--- a/ChangeGeneratorToVS2019.ps1
+++ b/ChangeGeneratorToVS2019.ps1
@@ -23,5 +23,6 @@ Update-JsonFile .\tests\export_cmake_and_install\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_cmake\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_dot_targets\CMakeSettings.json
 Update-JsonFile .\tests\export_simple_toolchain\CMakeSettings.json
+Update-JsonFile .\tests\write_autopkg_nested\CMakeSettings.json
 Update-JsonFile .\tests\write_autopkg_simple\CMakeSettings.json
 Update-JsonFile .\tests\write_nuspec_simple\CMakeSettings.json

--- a/ChangeGeneratorToVS2019.ps1
+++ b/ChangeGeneratorToVS2019.ps1
@@ -1,0 +1,27 @@
+function Update-CMakeFile() {
+	param([string] $fileName)
+
+    (Get-Content $fileName) | 
+        ForEach-Object{$_ -replace '-G "Visual Studio 15 2017 Win64"','-G "Visual Studio 16 2019" -A x64'} |
+            Set-Content $fileName
+}
+
+function Update-JsonFile() {
+	param([string] $fileName)
+
+    $text = [string]::Join("`r`n", (Get-Content $fileName))
+    [regex]::Replace($text, 
+                     """generator"": ""Visual Studio 15 2017 Win64"",",
+                     """generator"": ""Visual Studio 16 2019"",`r`n            ""architecture"": ""x64"",",
+                     "SingleLine") |
+        Set-Content $fileName -NoNewline
+}
+
+Update-CMakeFile .\build.cmake
+Update-CMakeFile .\CMakeLists.txt
+Update-JsonFile .\tests\export_cmake_and_install\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_cmake\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_dot_targets\CMakeSettings.json
+Update-JsonFile .\tests\export_simple_toolchain\CMakeSettings.json
+Update-JsonFile .\tests\write_autopkg_simple\CMakeSettings.json
+Update-JsonFile .\tests\write_nuspec_simple\CMakeSettings.json

--- a/cmake/internal/NuGetPack.autopkg.cmake
+++ b/cmake/internal/NuGetPack.autopkg.cmake
@@ -1,0 +1,356 @@
+## Internal. Section: /nuget/nuspec in .autopkg file (NUSPEC as section identifier CMake argument).
+function(nuget_internal_autopkg_process_nuspec_args AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT OUT_AUTOPKG_CONTENT OUT_PACKAGE_ID)
+    # Inputs
+    set(options REQUIRE_LICENSE_ACCEPTANCE)
+    set(oneValueArgs PACKAGE VERSION TITLE DESCRIPTION LICENSE_URL PROJECT_URL ICON
+        SUMMARY RELEASE_NOTES COPYRIGHT
+    )
+    set(multiValueArgs AUTHORS OWNERS TAGS)
+    cmake_parse_arguments(NUARG
+        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
+    )
+    nuget_internal_helper_error_if_unparsed_args(
+        "${NUARG_UNPARSED_ARGUMENTS}"
+        "${NUARG_KEYWORDS_MISSING_VALUES}"
+    )
+    # See http://coapp.org/reference/autopackage-ref.html for below requirements
+    nuget_internal_helper_error_if_empty("${NUARG_PACKAGE}" "PACKAGE must not be empty: it is a required element (/nuget/nuspec/id) of an .autopkg file.")
+    nuget_internal_helper_error_if_empty("${NUARG_VERSION}" "VERSION must not be empty: it is a required element (/nuget/nuspec/version) of an .autopkg file.")
+    nuget_internal_helper_error_if_empty("${NUARG_TITLE}" "TITLE must not be empty: it is a required element (/nuget/nuspec/title) of an .autopkg file.")
+    nuget_internal_helper_error_if_empty("${NUARG_DESCRIPTION}" "DESCRIPTION must not be empty: it is a required element (/nuget/nuspec/description) of an .autopkg file.")
+    nuget_internal_helper_error_if_empty("${NUARG_AUTHORS}" "AUTHORS must not be empty: it is a required element (/nuget/nuspec/authors) of an .autopkg file.")
+    nuget_internal_helper_error_if_empty("${NUARG_OWNERS}" "OWNERS must not be empty: it is a required element (/nuget/nuspec/owners) of an .autopkg file.")
+    # Actual functionality
+    # Begin /nuget/nuspec
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}nuspec {")
+    set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
+    # Required nuspec subelements
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}id = ${NUARG_PACKAGE};")
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}version: ${NUARG_VERSION};")
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}title: ${NUARG_TITLE};")
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}description: \"${NUARG_DESCRIPTION}\";")
+    string(REPLACE ";" "," AUTHORS "${NUARG_AUTHORS}")
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}authors: {${AUTHORS}};")
+    string(REPLACE ";" "," OWNERS "${NUARG_OWNERS}")
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}owners: {${OWNERS}};")
+
+    # Optional nuspec subelements
+    if(NOT "${NUARG_LICENSE_URL}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}licenseUrl: \"${NUARG_LICENSE_URL}\";")
+    endif()
+
+    if(NOT "${NUARG_PROJECT_URL}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}projectUrl: \"${NUARG_PROJECT_URL}\";")
+    endif()
+
+    if(NOT "${NUARG_ICON}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}iconUrl: \"${NUARG_ICON}\";")
+    endif()
+
+    if(NUARG_REQUIRE_LICENSE_ACCEPTANCE)
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}requireLicenseAcceptance: true;")
+    else()
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}requireLicenseAcceptance: false;")
+    endif()
+
+    if(NOT "${NUARG_SUMMARY}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}summary: \"${NUARG_SUMMARY}\";")
+    endif()
+
+    if(NOT "${NUARG_RELEASE_NOTES}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}releaseNotes: \"${NUARG_RELEASE_NOTES}\";")
+    endif()
+
+    if(NOT "${NUARG_COPYRIGHT}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}copyright: \"${NUARG_COPYRIGHT}\";")
+    endif()
+
+    if(NOT "${NUARG_TAGS}" STREQUAL "")
+        string(REPLACE ";" "," TAGS "${NUARG_TAGS}")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}tags: {${TAGS}};")
+    endif()
+
+    # End /nuget/nuspec
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}};")
+    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
+    set(${OUT_PACKAGE_ID} "${NUARG_PACKAGE}" PARENT_SCOPE)
+endfunction()
+
+## Internal. Section: /nuget/dependencies in .autopkg file.
+## Automatically generated based on previous nuget_add_dependencies() calls.
+## Only dependencies marked as PUBLIC or INTERFACE are added (ie. PRIVATE dependencies are omitted).
+function(nuget_internal_autopkg_add_dependencies AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT OUT_AUTOPKG_CONTENT)
+    # Begin /nuget/dependencies
+    set(AUTOPKG_DEPENDENCIES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}dependencies {\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}packages: {")
+    set(AUTOPKG_DEPENDENCIES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}};\n${AUTOPKG_INDENT_SIZE}};")
+    set(AUTOPKG_DEPENDENCIES_CONTENT "${AUTOPKG_DEPENDENCIES_CONTENT_BEGIN}")
+    # For each dependency that should be in /nuget/dependencies
+    nuget_get_dependencies(DEPENDENCIES)
+    set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
+
+    foreach(DEPENDENCY IN LISTS DEPENDENCIES)
+        nuget_get_dependency_usage("${DEPENDENCY}" USAGE)
+
+        if("${USAGE}" STREQUAL "PRIVATE")
+            continue()
+        endif()
+
+        nuget_get_dependency_version("${DEPENDENCY}" VERSION)
+        string(APPEND AUTOPKG_DEPENDENCIES_CONTENT "${DEPENDENCY_SEPARATOR}\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}${DEPENDENCY}/${VERSION}")
+        set(DEPENDENCY_SEPARATOR ",")
+    endforeach()
+
+    # End /nuget/dependencies
+    string(APPEND AUTOPKG_DEPENDENCIES_CONTENT "${AUTOPKG_DEPENDENCIES_CONTENT_END}")
+
+    if(NOT "${AUTOPKG_DEPENDENCIES_CONTENT}" STREQUAL "${AUTOPKG_DEPENDENCIES_CONTENT_BEGIN}${AUTOPKG_DEPENDENCIES_CONTENT_END}")
+        string(APPEND AUTOPKG_CONTENT "${AUTOPKG_DEPENDENCIES_CONTENT}")
+    endif()
+
+    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
+endfunction()
+
+## Internal. Section: /nuget/files in .autopkg file (FILES as section identifier CMake argument).
+function(nuget_internal_autopkg_process_files_args
+    AUTOPKG_INDENT_SIZE
+    AUTOPKG_CONTENT
+    CMAKE_ARCHITECTURE
+    CMAKE_PLATFORMTOOLSET
+    RELATIVE_OUTPUT_DIR
+    OUT_AUTOPKG_CONTENT
+)
+    # Begin /nuget/files
+    set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}files {\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}[$<LOWER_CASE:$<CONFIG>>")
+    if (NOT CMAKE_ARCHITECTURE STREQUAL "")
+        string(APPEND AUTOPKG_FILES_CONTENT_BEGIN ",${CMAKE_ARCHITECTURE}")
+    endif()
+    if (NOT CMAKE_PLATFORMTOOLSET STREQUAL "")
+        string(APPEND AUTOPKG_FILES_CONTENT_BEGIN ",${CMAKE_PLATFORMTOOLSET}")
+    endif()
+    string(APPEND AUTOPKG_FILES_CONTENT_BEGIN "] {")
+    set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}}\n${AUTOPKG_INDENT_SIZE}};")
+    set(AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_BEGIN}")
+    set(ARGS_HEAD "")
+    set(ARGS_TAIL ${ARGN})
+    set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
+
+    while(NOT "${ARGS_TAIL}" STREQUAL "")
+        nuget_internal_helper_cut_arg_list(CMAKE_CONDITIONAL_SECTION "${ARGS_TAIL}" ARGS_HEAD ARGS_TAIL)
+        list(LENGTH ARGS_HEAD ARGS_HEAD_LENGTH)
+
+        if(ARGS_HEAD_LENGTH GREATER_EQUAL 2)
+            list(GET ARGS_HEAD 0 MAYBE_CMAKE_INCLUDE_CONDITION_IDENTIFIER)
+
+            if("${MAYBE_CMAKE_INCLUDE_CONDITION_IDENTIFIER}" STREQUAL "CMAKE_CONDITIONAL_SECTION")
+                list(GET ARGS_HEAD 1 CMAKE_CONDITIONAL_SECTION)
+                nuget_internal_helper_list_sublist("${ARGS_HEAD}" 2 -1 ARGS_HEAD)
+            endif()
+        endif()
+
+        nuget_internal_autopkg_add_files_conditionally("${AUTOPKG_SUBELEMENT_INDENT_SIZE}" "${AUTOPKG_FILES_CONTENT}"
+            "${RELATIVE_OUTPUT_DIR}" AUTOPKG_FILES_CONTENT "${CMAKE_CONDITIONAL_SECTION}" ${ARGS_HEAD}
+        )
+    endwhile()
+
+    # End /nuget/files
+    string(APPEND AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_END}")
+
+    if("${AUTOPKG_FILES_CONTENT}" STREQUAL "${AUTOPKG_FILES_CONTENT_BEGIN}${AUTOPKG_FILES_CONTENT_END}")
+        message(FATAL_ERROR "Assembled expression for generating /nuget/files node(s) for .autopkg file(s) is empty.")
+    endif()
+
+    string(APPEND AUTOPKG_CONTENT "${AUTOPKG_FILES_CONTENT}")
+    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
+endfunction()
+
+## Internal.
+function(nuget_internal_autopkg_add_files_conditionally AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT RELATIVE_OUTPUT_DIR OUT_AUTOPKG_CONTENT CMAKE_CONDITIONAL_SECTION)
+    # Input: check for a CMAKE_CONDITIONAL_SECTION parameter pack
+    if(NOT "${CMAKE_CONDITIONAL_SECTION}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "$<${CMAKE_CONDITIONAL_SECTION}:")
+    endif()
+
+    nuget_internal_helper_error_if_empty("${ARGN}" "Input expression for generating elements under /nuget/files node(s) for .autopkg file(s) is empty: no FILE_SRC and FILE_TARGET arguments were provided.")
+    # Loop over parameter pack
+    set(ARGS_HEAD "")
+    set(ARGS_TAIL ${ARGN})
+
+    while(NOT "${ARGS_TAIL}" STREQUAL "")
+        nuget_internal_helper_cut_arg_list(FILE_SRC "${ARGS_TAIL}" ARGS_HEAD ARGS_TAIL)
+        nuget_internal_autopkg_add_file_conditionally("${AUTOPKG_INDENT_SIZE}" "${AUTOPKG_CONTENT}" "${RELATIVE_OUTPUT_DIR}" AUTOPKG_CONTENT
+            "${CMAKE_CONDITIONAL_SECTION}" ${ARGS_HEAD}
+        )
+    endwhile()
+
+    # Close generator expression if this was a CMAKE_CONDITIONAL_SECTION parameter pack
+    if(NOT "${CMAKE_CONDITIONAL_SECTION}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT ">")
+    endif()
+
+    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
+endfunction()
+
+## Internal.
+function(nuget_internal_autopkg_add_file_conditionally AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT RELATIVE_OUTPUT_DIR OUT_AUTOPKG_CONTENT CMAKE_CONDITIONAL_SECTION)
+    # Inputs
+    # See http://coapp.org/reference/autopackage-ref.html
+    set(options "")
+    set(oneValueArgs FILE_BIN_SRC FILE_SYMBOLS_SRC)
+    set(multiValueArgs FILE_EXCLUDE)
+    cmake_parse_arguments(NUARG
+        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
+    )
+    nuget_internal_helper_error_if_unparsed_args(
+        "${NUARG_UNPARSED_ARGUMENTS}"
+        "${NUARG_KEYWORDS_MISSING_VALUES}"
+    )
+    nuget_internal_helper_error_if_empty("${NUARG_FILE_BIN_SRC}"
+        "FILE_BIN_SRC must not be empty: it is a required attribute (bin) of "
+        "an .autopkg file's /nuget/files element."
+    )
+
+    # Actual functionality
+    if(NOT "${NUARG_FILE_SYMBOLS_SRC}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}symbols: \"${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_SYMBOLS_SRC}\";")
+    endif()
+
+    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}bin: \"${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_BIN_SRC}\";")
+
+    if(NOT "${NUARG_FILE_EXCLUDE}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT " exclude=\"${NUARG_FILE_EXCLUDE}\"")
+    endif()
+
+    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
+endfunction()
+
+## Internal. Section: CMake-specific (without special section identifier CMake argument).
+## Write output .autopkg file(s) conditionally for provided configurations in CMAKE_CONFIGURATIONS intersected with
+## the available configurations in the current build system this function is actually called from. No error is raised if
+## a given configuration is not available -- the output file is simply not generated for that in the current build system.
+## Not raising an error if a given configuration is unavailable makes it possible to reuse the same nuget_generate_autopkg_files()
+## calls across different build systems without adjustments or writing additional code for generating the values of the
+## CMAKE_CONFIGURATIONS argument.
+function(nuget_internal_autopkg_generate_output AUTOPKG_CONTENT PACKAGE_ID CMAKE_OUTPUT_DIR CMAKE_CONFIGURATIONS)
+    # Inputs
+    nuget_internal_helper_error_if_empty("${AUTOPKG_CONTENT}" "AUTOPKG_CONTENT to be written is empty: cannot generate .autopkg file's content.")
+    nuget_internal_helper_error_if_empty("${PACKAGE_ID}" "PACKAGE_ID to be written is empty: cannot generate .autopkg filename.")
+
+    if("${CMAKE_OUTPUT_DIR}" STREQUAL "")
+        set(OUTPUT_FILE "${CMAKE_BINARY_DIR}/CMakeNuGetTools/autopkg/${PACKAGE_ID}.$<CONFIG>.autopkg")
+    else()
+        set(OUTPUT_FILE "${CMAKE_OUTPUT_DIR}/${PACKAGE_ID}.$<CONFIG>.autopkg")
+    endif()
+
+    # Actual functionality
+    if("${CMAKE_CONFIGURATIONS}" STREQUAL "")
+        file(GENERATE OUTPUT "${OUTPUT_FILE}" CONTENT "${AUTOPKG_CONTENT}")
+        message(STATUS "Written \"${OUTPUT_FILE}\" file(s).")
+    else()
+        set(CONDITIONS "$<OR:")
+
+        foreach(CONFIGURATION IN LISTS CMAKE_CONFIGURATIONS)
+            string(APPEND CONDITIONS "${CONDITIONS_SEPARATOR}$<CONFIG:${CONFIGURATION}>")
+            set(CONDITIONS_SEPARATOR ",")
+        endforeach()
+
+        string(APPEND CONDITIONS ">")
+        file(GENERATE OUTPUT "${OUTPUT_FILE}" CONTENT "${AUTOPKG_CONTENT}" CONDITION "${CONDITIONS}")
+        message(STATUS "Written \"${OUTPUT_FILE}\" file(s) for \"${CMAKE_CONFIGURATIONS}\" configuration(s).")
+    endif()
+endfunction()
+
+## Internal.
+function(nuget_internal_merge_second_autopkg_file_into_first FILEPATH_ACC FILEPATH_IN)
+    set(FILES_NODE_BEGIN_STR "files {")
+    set(FILES_NODE_END_STR "}\\;")
+    string(LENGTH "${FILES_NODE_BEGIN_STR}" FILES_NODE_BEGIN_LEN)
+    string(LENGTH "${FILES_NODE_END_STR}" FILES_NODE_END_LEN)
+    # Inputs: FILEPATH_IN
+    file(STRINGS "${FILEPATH_IN}" LINES_IN NEWLINE_CONSUME ENCODING UTF-8)
+    string(FIND "${LINES_IN}" "${FILES_NODE_BEGIN_STR}" LINES_IN_FILES_NODE_BEGIN_POS)
+
+    if(${LINES_IN_FILES_NODE_BEGIN_POS} EQUAL -1)
+        message(FATAL_ERROR "Cannot merge: did not find the \"${FILES_NODE_BEGIN_STR}\" part of the .autopkg files node in \"${FILEPATH_IN}\".")
+    endif()
+
+    string(FIND "${LINES_IN}" "${FILES_NODE_END_STR}" LINES_IN_FILES_NODE_END_POS REVERSE)
+
+    if(${LINES_IN_FILES_NODE_END_POS} EQUAL -1)
+        message(FATAL_ERROR "Cannot merge: did not find the \"${FILES_NODE_END_STR}\" part of the .autopkg files node in \"${FILEPATH_IN}\".")
+    endif()
+
+    # Inputs: FILEPATH_ACC
+    file(STRINGS "${FILEPATH_ACC}" LINES_ACC NEWLINE_CONSUME ENCODING UTF-8)
+    string(FIND "${LINES_ACC}" "${FILES_NODE_BEGIN_STR}" LINES_ACC_FILES_NODE_BEGIN_POS)
+
+    if(${LINES_ACC_FILES_NODE_BEGIN_POS} EQUAL -1)
+        message(FATAL_ERROR "Cannot merge: did not find the \"${FILES_NODE_BEGIN_STR}\" part of the .autopkg files node in \"${FILEPATH_ACC}\".")
+    endif()
+
+    string(FIND "${LINES_ACC}" "${FILES_NODE_END_STR}" LINES_ACC_FILES_NODE_END_POS REVERSE)
+
+    if(${LINES_ACC_FILES_NODE_END_POS} EQUAL -1)
+        message(FATAL_ERROR "Cannot merge: did not find the \"${FILES_NODE_END_STR}\" part of the .autopkg files node in \"${FILEPATH_ACC}\".")
+    endif()
+
+    # Check: FILEPATH_ACC and FILEPATH_IN contents outside the files node should not differ
+    string(SUBSTRING "${LINES_IN}" 0 ${LINES_IN_FILES_NODE_BEGIN_POS} LINES_IN_UNTIL_FILES_NODE_BEGIN)
+    string(SUBSTRING "${LINES_ACC}" 0 ${LINES_ACC_FILES_NODE_BEGIN_POS} LINES_ACC_UNTIL_FILES_NODE_BEGIN)
+
+    if(NOT "${LINES_IN_UNTIL_FILES_NODE_BEGIN}" STREQUAL "${LINES_ACC_UNTIL_FILES_NODE_BEGIN}")
+        message(FATAL_ERROR "Cannot merge: file content before the .autopkg files node of \"${FILEPATH_ACC}\" and \"${FILEPATH_IN}\" differs.")
+    endif()
+
+    string(SUBSTRING "${LINES_IN}" ${LINES_IN_FILES_NODE_END_POS} -1 LINES_IN_AFTER_FILES_NODE_END)
+    string(SUBSTRING "${LINES_ACC}" ${LINES_ACC_FILES_NODE_END_POS} -1 LINES_ACC_AFTER_FILES_NODE_END)
+
+    if(NOT "${LINES_IN_AFTER_FILES_NODE_END}" STREQUAL "${LINES_ACC_AFTER_FILES_NODE_END}")
+        message(FATAL_ERROR "Cannot merge: file content after the .autopkg files node of \"${FILEPATH_ACC}\" and \"${FILEPATH_IN}\" differs.")
+    endif()
+
+    # Create merged content
+    # NOTE: no need to check for duplicate <file> element entries when merging FILEPATH_ACC and FILEPATH_IN: nuget pack does not
+    # seem to complain when file elements with the same src and target attributes are present in the files node of a .autopkg file.
+    string(SUBSTRING "${LINES_ACC}" 0 ${LINES_ACC_FILES_NODE_END_POS} NEW_LINES_ACC)
+    string(APPEND NEW_LINES_ACC "${NUGET_AUTOPKG_INDENT_SIZE}// Below merged from: \"${FILEPATH_IN}\"")
+    math(EXPR LINES_IN_AFTER_FILES_NODE_BEGIN_POS "${LINES_IN_FILES_NODE_BEGIN_POS} + ${FILES_NODE_BEGIN_LEN}")
+    string(SUBSTRING "${LINES_IN}" ${LINES_IN_AFTER_FILES_NODE_BEGIN_POS} -1 LINES_IN_AFTER_FILES_NODE_BEGIN)
+    string(APPEND NEW_LINES_ACC "${LINES_IN_AFTER_FILES_NODE_BEGIN}")
+    # Output: overwrite FILEPATH_ACC with merged content
+    set(NEW_FILE_CONTENT_ACC "${NEW_LINES_ACC}")
+    string(REPLACE "\\;" ";" NEW_FILE_CONTENT_ACC "${NEW_FILE_CONTENT_ACC}")
+    file(WRITE "${FILEPATH_ACC}" "${NEW_FILE_CONTENT_ACC}")
+endfunction()
+
+## Internal.
+function(nuget_internal_merge_n_autopkg_files FILEPATH_ACC)
+    nuget_internal_helper_error_if_empty("${FILEPATH_ACC}" "No filepath to a .autopkg file provided as a basis for merge operation.")
+    nuget_internal_helper_error_if_empty("${ARGN}" "No .autopkg filepaths provided for merge operation.")
+    # Read first input file (FILEPATH_BASE)
+    list(GET ARGN 0 FILEPATH_BASE)
+    file(STRINGS "${FILEPATH_BASE}" LINES_BASE NEWLINE_CONSUME ENCODING UTF-8)
+    # Inputs: FILEPATH_BASE
+    set(FILES_NODE_BEGIN_STR "files {")
+    string(LENGTH "${FILES_NODE_BEGIN_STR}" FILES_NODE_BEGIN_LEN)
+    string(FIND "${LINES_BASE}" "${FILES_NODE_BEGIN_STR}" LINES_BASE_FILES_NODE_BEGIN_POS)
+
+    if(${LINES_BASE_FILES_NODE_BEGIN_POS} EQUAL -1)
+        message(FATAL_ERROR "Cannot merge: did not find the \"${FILES_NODE_BEGIN_STR}\" part of the .autopkg files node in \"${FILEPATH_BASE}\".")
+    endif()
+    
+    # Initialize content of FILEPATH_ACC with FILEPATH_BASE adding comment referring to original source file
+    math(EXPR LINES_BASE_AFTER_FILES_NODE_BEGIN_POS "${LINES_BASE_FILES_NODE_BEGIN_POS} + ${FILES_NODE_BEGIN_LEN}")
+    string(SUBSTRING "${LINES_BASE}" 0 ${LINES_BASE_AFTER_FILES_NODE_BEGIN_POS} NEW_LINES_BASE)
+    string(APPEND NEW_LINES_BASE "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}// Below loaded from: \"${FILEPATH_BASE}\"")
+    string(SUBSTRING "${LINES_BASE}" ${LINES_BASE_AFTER_FILES_NODE_BEGIN_POS} -1 LINES_BASE_AFTER_FILES_NODE_BEGIN)
+    string(APPEND NEW_LINES_BASE "${LINES_BASE_AFTER_FILES_NODE_BEGIN}")
+    set(NEW_FILE_CONTENT_BASE "${NEW_LINES_BASE}")
+    string(REPLACE "\\;" ";" NEW_FILE_CONTENT_BASE "${NEW_FILE_CONTENT_BASE}")
+    file(WRITE "${FILEPATH_ACC}" "${NEW_FILE_CONTENT_BASE}")
+    # Merge rest of the input files into FILEPATH_ACC
+    nuget_internal_helper_list_sublist("${ARGN}" 1 -1 FILEPATHS_IN_TAIL)
+
+    foreach(FILEPATH_IN IN LISTS FILEPATHS_IN_TAIL)
+        nuget_internal_merge_second_autopkg_file_into_first("${FILEPATH_ACC}" "${FILEPATH_IN}")
+    endforeach()
+endfunction()

--- a/cmake/internal/NuGetPack.autopkg.cmake
+++ b/cmake/internal/NuGetPack.autopkg.cmake
@@ -122,7 +122,7 @@ function(nuget_internal_autopkg_process_files_args
 )
     set(options "")
     set(oneValueArgs "")
-    set(multiValueArgs CMAKE_CONFIGURATIONS INCLUDES NESTEDINCLUDES OUTPUTS)
+    set(multiValueArgs CMAKE_CONFIGURATIONS INCLUDES OUTPUTS)
     cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
     # Begin /nuget/files
@@ -137,16 +137,6 @@ function(nuget_internal_autopkg_process_files_args
             "${CMAKE_OUTPUT_DIR}"
             AUTOPKG_FILES_CONTENT
             ${NUARG_INCLUDES}
-        )
-    endif()
-
-    if (NOT "${NUARG_NESTEDINCLUDES}" STREQUAL "")
-        nuget_internal_autopkg_process_files_nestedincludes_args(
-            "${AUTOPKG_INDENT_SIZE}"
-            "${AUTOPKG_FILES_CONTENT}"
-            "${CMAKE_OUTPUT_DIR}"
-            AUTOPKG_FILES_CONTENT
-            ${NUARG_NESTEDINCLUDES}
         )
     endif()
 
@@ -183,7 +173,7 @@ function(nuget_internal_autopkg_process_files_includes_args
     # Inputs
     # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html
     set(options "")
-    set(oneValueArgs "")
+    set(oneValueArgs FILE_INCLUDE_DEST)
     set(multiValueArgs FILE_INCLUDE_SRC)
     cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
@@ -191,48 +181,19 @@ function(nuget_internal_autopkg_process_files_includes_args
         "attribute of an .autopkg file's /nuget/files/include element."
     )
 
-    set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}include: {")
+    if (NOT "${NUARG_FILE_INCLUDE_DEST}" STREQUAL "")
+        set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}nestedInclude: {")
+    else()
+        set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}include: {")
+    endif()
     set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}};")
     set(AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_BEGIN}")
     set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
     cmake_path(RELATIVE_PATH CMAKE_SOURCE_DIR BASE_DIRECTORY ${CMAKE_OUTPUT_DIR} OUTPUT_VARIABLE RELATIVE_OUTPUT_DIR)
 
-    foreach(FILE_INCLUDE_SRC ${NUARG_FILE_INCLUDE_SRC})
-        string(APPEND AUTOPKG_FILES_CONTENT "${SEPARATOR}")
-        string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}${RELATIVE_OUTPUT_DIR}/${FILE_INCLUDE_SRC}")
-        set(SEPARATOR ",")
-    endforeach()
-
-    string(APPEND AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_END}")
-    string(APPEND AUTOPKG_CONTENT "${AUTOPKG_FILES_CONTENT}")
-    set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
-endfunction()
-
-## Internal.
-function(nuget_internal_autopkg_process_files_nestedincludes_args
-    AUTOPKG_INDENT_SIZE
-    AUTOPKG_CONTENT
-    CMAKE_OUTPUT_DIR
-    OUT_AUTOPKG_CONTENT
-)
-    # Inputs
-    # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html
-    set(options "")
-    set(oneValueArgs FILE_INCLUDE_DEST)
-    set(multiValueArgs FILE_INCLUDE_SRC)
-    cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-    nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
-    nuget_internal_helper_error_if_empty("${NUARG_FILE_INCLUDE_DEST}" "FILE_INCLUDE_DEST and FILE_INCLUDE_SRC must not both be " +
-        "empty: it is a required attribute of an .autopkg file's /nuget/files/nestedInclude element."
-    )
-
-    set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}nestedInclude: {")
-    set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}};")
-    set(AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_BEGIN}")
-    set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
-    cmake_path(RELATIVE_PATH CMAKE_SOURCE_DIR BASE_DIRECTORY ${CMAKE_OUTPUT_DIR} OUTPUT_VARIABLE RELATIVE_OUTPUT_DIR)
-
-    string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}#destination = ${NUARG_FILE_INCLUDE_DEST};")
+    if (NOT "${NUARG_FILE_INCLUDE_DEST}" STREQUAL "")
+        string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}#destination = ${NUARG_FILE_INCLUDE_DEST};")
+    endif()
 
     foreach(FILE_INCLUDE_SRC ${NUARG_FILE_INCLUDE_SRC})
         string(APPEND AUTOPKG_FILES_CONTENT "${SEPARATOR}")

--- a/cmake/internal/NuGetPack.autopkg.cmake
+++ b/cmake/internal/NuGetPack.autopkg.cmake
@@ -122,14 +122,9 @@ function(nuget_internal_autopkg_process_files_args
 )
     set(options "")
     set(oneValueArgs "")
-    set(multiValueArgs CMAKE_CONFIGURATIONS INCLUDES OUTPUTS)
-    cmake_parse_arguments(NUARG
-        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
-    )
-    nuget_internal_helper_error_if_unparsed_args(
-        "${NUARG_UNPARSED_ARGUMENTS}"
-        "${NUARG_KEYWORDS_MISSING_VALUES}"
-    )
+    set(multiValueArgs CMAKE_CONFIGURATIONS INCLUDES NESTEDINCLUDES OUTPUTS)
+    cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
     # Begin /nuget/files
     set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}files {")
     set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}};")
@@ -142,6 +137,16 @@ function(nuget_internal_autopkg_process_files_args
             "${CMAKE_OUTPUT_DIR}"
             AUTOPKG_FILES_CONTENT
             ${NUARG_INCLUDES}
+        )
+    endif()
+
+    if (NOT "${NUARG_NESTEDINCLUDES}" STREQUAL "")
+        nuget_internal_autopkg_process_files_nestedincludes_args(
+            "${AUTOPKG_INDENT_SIZE}"
+            "${AUTOPKG_FILES_CONTENT}"
+            "${CMAKE_OUTPUT_DIR}"
+            AUTOPKG_FILES_CONTENT
+            ${NUARG_NESTEDINCLUDES}
         )
     endif()
 
@@ -175,58 +180,72 @@ function(nuget_internal_autopkg_process_files_includes_args
     CMAKE_OUTPUT_DIR
     OUT_AUTOPKG_CONTENT
 )
-    nuget_internal_helper_error_if_empty("${ARGN}" "Input expression for generating include elements under /nuget/files/include node(s) for .autopkg file(s) is empty: no FILE_INCLUDE_SRC arguments were provided.")
+    # Inputs
+    # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html
+    set(options "")
+    set(oneValueArgs "")
+    set(multiValueArgs FILE_INCLUDE_SRC)
+    cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
+    nuget_internal_helper_error_if_empty("${NUARG_FILE_INCLUDE_SRC}" "FILE_INCLUDE_SRC must not be empty: it is a required " +
+        "attribute of an .autopkg file's /nuget/files/include element."
+    )
 
     set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}include: {")
     set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}};")
     set(AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_BEGIN}")
-    set(ARGS_HEAD "")
-    set(ARGS_TAIL ${ARGN})
     set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
     cmake_path(RELATIVE_PATH CMAKE_SOURCE_DIR BASE_DIRECTORY ${CMAKE_OUTPUT_DIR} OUTPUT_VARIABLE RELATIVE_OUTPUT_DIR)
 
-    while(NOT "${ARGS_TAIL}" STREQUAL "")
+    foreach(FILE_INCLUDE_SRC ${NUARG_FILE_INCLUDE_SRC})
         string(APPEND AUTOPKG_FILES_CONTENT "${SEPARATOR}")
-        nuget_internal_helper_cut_arg_list(FILE_INCLUDE_SRC "${ARGS_TAIL}" ARGS_HEAD ARGS_TAIL)
-        nuget_internal_autopkg_add_include_file("${AUTOPKG_SUBELEMENT_INDENT_SIZE}" "${AUTOPKG_FILES_CONTENT}" "${RELATIVE_OUTPUT_DIR}"
-        AUTOPKG_FILES_CONTENT ${ARGS_HEAD}
-        )
+        string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}${RELATIVE_OUTPUT_DIR}/${FILE_INCLUDE_SRC}")
         set(SEPARATOR ",")
-    endwhile()
+    endforeach()
 
-    # End /nuget/files
     string(APPEND AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_END}")
-
-    if("${AUTOPKG_FILES_CONTENT}" STREQUAL "${AUTOPKG_FILES_CONTENT_BEGIN}${AUTOPKG_FILES_CONTENT_END}")
-        message(FATAL_ERROR "Assembled expression for generating /nuget/files node(s) for .autopkg file(s) is empty.")
-    endif()
-
     string(APPEND AUTOPKG_CONTENT "${AUTOPKG_FILES_CONTENT}")
     set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
 endfunction()
 
 ## Internal.
-function(nuget_internal_autopkg_add_include_file AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT RELATIVE_OUTPUT_DIR OUT_AUTOPKG_CONTENT)
+function(nuget_internal_autopkg_process_files_nestedincludes_args
+    AUTOPKG_INDENT_SIZE
+    AUTOPKG_CONTENT
+    CMAKE_OUTPUT_DIR
+    OUT_AUTOPKG_CONTENT
+)
     # Inputs
     # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html
     set(options "")
-    set(oneValueArgs FILE_INCLUDE_SRC)
-    set(multiValueArgs FILE_EXCLUDE)
-    cmake_parse_arguments(NUARG
-        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
-    )
-    nuget_internal_helper_error_if_unparsed_args(
-        "${NUARG_UNPARSED_ARGUMENTS}"
-        "${NUARG_KEYWORDS_MISSING_VALUES}"
-    )
-    nuget_internal_helper_error_if_empty("${NUARG_FILE_INCLUDE_SRC}"
-        "FILE_INCLUDE_SRC must not both be empty: it is a required attribute of an .autopkg file's /nuget/files/include element."
+    set(oneValueArgs FILE_INCLUDE_DEST)
+    set(multiValueArgs FILE_INCLUDE_SRC)
+    cmake_parse_arguments(NUARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    nuget_internal_helper_error_if_unparsed_args("${NUARG_UNPARSED_ARGUMENTS}" "${NUARG_KEYWORDS_MISSING_VALUES}")
+    nuget_internal_helper_error_if_empty("${NUARG_FILE_INCLUDE_DEST}" "FILE_INCLUDE_DEST and FILE_INCLUDE_SRC must not both be " +
+        "empty: it is a required attribute of an .autopkg file's /nuget/files/nestedInclude element."
     )
 
-    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_INCLUDE_SRC}")
+    set(AUTOPKG_FILES_CONTENT_BEGIN "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}nestedInclude: {")
+    set(AUTOPKG_FILES_CONTENT_END "\n${AUTOPKG_INDENT_SIZE}${AUTOPKG_INDENT_SIZE}};")
+    set(AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_BEGIN}")
+    set(AUTOPKG_SUBELEMENT_INDENT_SIZE "${AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}")
+    cmake_path(RELATIVE_PATH CMAKE_SOURCE_DIR BASE_DIRECTORY ${CMAKE_OUTPUT_DIR} OUTPUT_VARIABLE RELATIVE_OUTPUT_DIR)
+
+    string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}#destination = ${NUARG_FILE_INCLUDE_DEST};")
+
+    foreach(FILE_INCLUDE_SRC ${NUARG_FILE_INCLUDE_SRC})
+        string(APPEND AUTOPKG_FILES_CONTENT "${SEPARATOR}")
+        string(APPEND AUTOPKG_FILES_CONTENT "\n${AUTOPKG_SUBELEMENT_INDENT_SIZE}${RELATIVE_OUTPUT_DIR}/${FILE_INCLUDE_SRC}")
+        set(SEPARATOR ",")
+    endforeach()
+
+    string(APPEND AUTOPKG_FILES_CONTENT "${AUTOPKG_FILES_CONTENT_END}")
+    string(APPEND AUTOPKG_CONTENT "${AUTOPKG_FILES_CONTENT}")
     set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
 endfunction()
 
+## Internal.
 function(nuget_internal_autopkg_process_files_outputs_args
     AUTOPKG_INDENT_SIZE
     AUTOPKG_CONTENT
@@ -279,6 +298,7 @@ function(nuget_internal_autopkg_process_files_outputs_args
     set(${OUT_AUTOPKG_CONTENT} "${AUTOPKG_CONTENT}" PARENT_SCOPE)
 endfunction()
 
+## Internal.
 function(nuget_internal_autopkg_add_files_outputs_conditionally AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT RELATIVE_OUTPUT_DIR OUT_AUTOPKG_CONTENT CMAKE_CONDITIONAL_SECTION)
     # Input: check for a CMAKE_CONDITIONAL_SECTION parameter pack
     if(NOT "${CMAKE_CONDITIONAL_SECTION}" STREQUAL "")

--- a/cmake/internal/NuGetPack.autopkg.cmake
+++ b/cmake/internal/NuGetPack.autopkg.cmake
@@ -13,7 +13,7 @@ function(nuget_internal_autopkg_process_nuspec_args AUTOPKG_INDENT_SIZE AUTOPKG_
         "${NUARG_UNPARSED_ARGUMENTS}"
         "${NUARG_KEYWORDS_MISSING_VALUES}"
     )
-    # See http://coapp.org/reference/autopackage-ref.html for below requirements
+    # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html for below requirements
     nuget_internal_helper_error_if_empty("${NUARG_PACKAGE}" "PACKAGE must not be empty: it is a required element (/nuget/nuspec/id) of an .autopkg file.")
     nuget_internal_helper_error_if_empty("${NUARG_VERSION}" "VERSION must not be empty: it is a required element (/nuget/nuspec/version) of an .autopkg file.")
     nuget_internal_helper_error_if_empty("${NUARG_TITLE}" "TITLE must not be empty: it is a required element (/nuget/nuspec/title) of an .autopkg file.")
@@ -193,7 +193,7 @@ endfunction()
 ## Internal.
 function(nuget_internal_autopkg_add_file_conditionally AUTOPKG_INDENT_SIZE AUTOPKG_CONTENT RELATIVE_OUTPUT_DIR OUT_AUTOPKG_CONTENT CMAKE_CONDITIONAL_SECTION)
     # Inputs
-    # See http://coapp.org/reference/autopackage-ref.html
+    # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html
     set(options "")
     set(oneValueArgs FILE_BIN_SRC FILE_SYMBOLS_SRC)
     set(multiValueArgs FILE_EXCLUDE)
@@ -204,17 +204,19 @@ function(nuget_internal_autopkg_add_file_conditionally AUTOPKG_INDENT_SIZE AUTOP
         "${NUARG_UNPARSED_ARGUMENTS}"
         "${NUARG_KEYWORDS_MISSING_VALUES}"
     )
-    nuget_internal_helper_error_if_empty("${NUARG_FILE_BIN_SRC}"
-        "FILE_BIN_SRC must not be empty: it is a required attribute (bin) of "
-        "an .autopkg file's /nuget/files element."
+    nuget_internal_helper_error_if_empty("${NUARG_FILE_BIN_SRC}${NUARG_FILE_SYMBOLS_SRC}"
+        "FILE_BIN_SRC and FILE_SYMBOLS_SRC must not both be empty: one of them is a required "
+        "attribute (bin or symbols) of an .autopkg file's /nuget/files element."
     )
 
     # Actual functionality
+    if(NOT "${NUARG_FILE_BIN_SRC}" STREQUAL "")
+        string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}bin: \"${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_BIN_SRC}\";")
+    endif()
+
     if(NOT "${NUARG_FILE_SYMBOLS_SRC}" STREQUAL "")
         string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}symbols: \"${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_SYMBOLS_SRC}\";")
     endif()
-
-    string(APPEND AUTOPKG_CONTENT "\n${AUTOPKG_INDENT_SIZE}bin: \"${RELATIVE_OUTPUT_DIR}/${NUARG_FILE_BIN_SRC}\";")
 
     if(NOT "${NUARG_FILE_EXCLUDE}" STREQUAL "")
         string(APPEND AUTOPKG_CONTENT " exclude=\"${NUARG_FILE_EXCLUDE}\"")

--- a/cmake/internal/NuGetPack.cmake
+++ b/cmake/internal/NuGetPack.cmake
@@ -164,13 +164,13 @@ function(nuget_generate_autopkg_files)
     message(STATUS "Writing .autopkg file(s)...")
     # Begin .autopkg file
     # Start with the configuration that is needed to create packages for VS2015 (v140), see https://github.com/coapp/coapp.powershell/issues/112.
-    # See http://coapp.org/reference/autopackage-ref.html for the default for 'choises'.
+    # See http://coapp.org/developers/autopackage.html and http://coapp.org/reference/autopackage-ref.html for the default for 'choises'.
     set(AUTOPKG_CONTENT "configurations {")
     # This node contains custom pivot information.
     string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}Toolset {")
     #  This is CoApp pre-defined key.
     string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}key: \"PlatformToolset\";")
-    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}choices: { v140, v120, v110, v100, v90, v80, v71, v70, v60, gcc };")
+    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}choices: { v142, v141, v140, v120, v110, v100, v90, v80, v71, v70, v60, gcc };")
     string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}};")
     string(APPEND AUTOPKG_CONTENT "\n}")
     string(APPEND AUTOPKG_CONTENT "\nnuget {")

--- a/cmake/internal/NuGetPack.cmake
+++ b/cmake/internal/NuGetPack.cmake
@@ -205,9 +205,10 @@ function(nuget_generate_autopkg_files)
         "${AUTOPKG_CONTENT}"
         ${NUARG_CMAKE_ARCHITECTURE}
         ${NUARG_CMAKE_PLATFORMTOOLSET}
+        "${NUARG_CMAKE_OUTPUT_DIR}"
         "${RELATIVE_OUTPUT_DIR}"
         AUTOPKG_CONTENT
-        ${NUARG_FILES}
+        "${NUARG_FILES}"
     )
     # End .autopkg file
     string(APPEND AUTOPKG_CONTENT "\n}")

--- a/cmake/internal/NuGetPack.cmake
+++ b/cmake/internal/NuGetPack.cmake
@@ -1,10 +1,16 @@
 ## Include implementation
 include("${CMAKE_CURRENT_LIST_DIR}/NuGetPack.nuspec.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/NuGetPack.autopkg.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/NuGetPack.nupkg.cmake")
 
 ## Internal cache variables
 set(NUGET_NUSPEC_INDENT_SIZE "  " CACHE INTERNAL
     "Specifies the size of a single indentation level for generated .nuspec files."
+)
+
+## Internal cache variables
+set(NUGET_AUTOPKG_INDENT_SIZE "    " CACHE INTERNAL
+    "Specifies the size of a single indentation level for generated .autopkg files."
 )
 
 ## Public interface.
@@ -140,4 +146,109 @@ function(nuget_pack_push)
     nuget_internal_helper_error_if_empty("${NUARG_SOURCE}" "SOURCE must be non-empty.")
     # Actual functionality
     nuget_internal_pack_push("${NUARG_PACKAGE_PATH}" "${NUARG_API_KEY}" "${NUARG_SOURCE}")
+endfunction()
+
+## Public interface.
+function(nuget_generate_autopkg_files)
+    # Sanity checks
+    if("${NUGET_COMMAND}" STREQUAL "")
+        message(STATUS "NUGET_COMMAND is empty: CMakeNuGetTools is disabled, no .autopkg files are written.")
+        return()
+    endif()
+
+    if("${ARGV}" STREQUAL "")
+        message(FATAL_ERROR "No arguments provided.")
+        return()
+    endif()
+
+    message(STATUS "Writing .autopkg file(s)...")
+    # Begin .autopkg file
+    # Start with the configuration that is needed to create packages for VS2015 (v140), see https://github.com/coapp/coapp.powershell/issues/112.
+    # See http://coapp.org/reference/autopackage-ref.html for the default for 'choises'.
+    set(AUTOPKG_CONTENT "configurations {")
+    # This node contains custom pivot information.
+    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}Toolset {")
+    #  This is CoApp pre-defined key.
+    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}key: \"PlatformToolset\";")
+    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}${NUGET_AUTOPKG_INDENT_SIZE}choices: { v140, v120, v110, v100, v90, v80, v71, v70, v60, gcc };")
+    string(APPEND AUTOPKG_CONTENT "\n${NUGET_AUTOPKG_INDENT_SIZE}};")
+    string(APPEND AUTOPKG_CONTENT "\n}")
+    string(APPEND AUTOPKG_CONTENT "\nnuget {")
+    # Process arguments
+    set(options "")
+    set(oneValueArgs CMAKE_OUTPUT_DIR CMAKE_ARCHITECTURE CMAKE_PLATFORMTOOLSET)
+    set(multiValueArgs CMAKE_CONFIGURATIONS NUSPEC FILES)
+    cmake_parse_arguments(NUARG
+        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGV}
+    )
+    nuget_internal_helper_error_if_unparsed_args(
+        "${NUARG_UNPARSED_ARGUMENTS}"
+        "${NUARG_KEYWORDS_MISSING_VALUES}"
+    )
+    # NUSPEC arg: /nuget/nuspec in .autopkg file (NUSPEC as section identifier CMake argument)
+    nuget_internal_helper_error_if_empty("${NUARG_NUSPEC}" "NUSPEC identifier is not found: it is a required element (/nuget/nuspec) of an .autopkg file.")
+    string(APPEND TARGET_OUTPUT_DIR ${CMAKE_BINARY_DIR})
+    string(APPEND TARGET_OUTPUT_DIR "/$<CONFIG>")
+    cmake_path(RELATIVE_PATH TARGET_OUTPUT_DIR BASE_DIRECTORY ${NUARG_CMAKE_OUTPUT_DIR} OUTPUT_VARIABLE RELATIVE_OUTPUT_DIR)
+    nuget_internal_autopkg_process_nuspec_args("${NUGET_AUTOPKG_INDENT_SIZE}" "${AUTOPKG_CONTENT}" AUTOPKG_CONTENT PACKAGE_ID ${NUARG_NUSPEC})
+    # Optional collection subelements
+    # Section: /nuget/dependencies -- add package dependencies that are marked as PUBLIC or INTERFACE
+    # in previous nuget_add_dependencies() calls.
+    nuget_internal_autopkg_add_dependencies("${NUGET_AUTOPKG_INDENT_SIZE}" "${AUTOPKG_CONTENT}" AUTOPKG_CONTENT)
+    # FILES arg: /package/files in .nuspec XML file (FILES as section identifier CMake argument)
+    nuget_internal_helper_error_if_empty("${NUARG_FILES}"
+        "FILES must not be empty: although the files node is not a required element (/nuget/files) of an .autopkg file, "
+        "the implementation of the nuget_generate_autopkg_files() CMake command requires you to generate a non-empty files node."
+    )
+    nuget_internal_autopkg_process_files_args(
+        "${NUGET_AUTOPKG_INDENT_SIZE}"
+        "${AUTOPKG_CONTENT}"
+        ${NUARG_CMAKE_ARCHITECTURE}
+        ${NUARG_CMAKE_PLATFORMTOOLSET}
+        "${RELATIVE_OUTPUT_DIR}"
+        AUTOPKG_CONTENT
+        ${NUARG_FILES}
+    )
+    # End .autopkg file
+    string(APPEND AUTOPKG_CONTENT "\n}")
+    # Write output file(s)
+    # Top-level CMAKE_* args: CMake-specific (without special section identifier CMake argument)
+    nuget_internal_autopkg_generate_output("${AUTOPKG_CONTENT}" "${PACKAGE_ID}" "${NUARG_CMAKE_OUTPUT_DIR}" "${NUARG_CMAKE_CONFIGURATIONS}")
+endfunction()
+
+## Public interface.
+function(nuget_merge_autopkg_files)
+    # Inputs
+    set(options "")
+    set(oneValueArgs OUTPUT)
+    set(multiValueArgs INPUTS)
+    cmake_parse_arguments(NUARG
+        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGV}
+    )
+    nuget_internal_helper_error_if_unparsed_args(
+        "${NUARG_UNPARSED_ARGUMENTS}"
+        "${NUARG_KEYWORDS_MISSING_VALUES}"
+    )
+    nuget_internal_helper_error_if_empty("${NUARG_OUTPUT}" "You must provide a filepath as an OUTPUT argument.")
+    nuget_internal_helper_error_if_empty("${NUARG_INPUTS}" "You must provide at least one filepath to a .nuspec file as an INPUTS argument.")
+    # Actual functionality
+    nuget_internal_merge_n_autopkg_files("${NUARG_OUTPUT}" ${NUARG_INPUTS})
+endfunction()
+
+## Public interface.
+function(nuget_pack_autopkg)
+    # Inputs
+    set(options "")
+    set(oneValueArgs AUTOPKG_FILEPATH)
+    set(multiValueArgs "")
+    cmake_parse_arguments(NUARG
+        "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGV}
+    )
+    nuget_internal_helper_error_if_unparsed_args(
+        "${NUARG_UNPARSED_ARGUMENTS}"
+        "${NUARG_KEYWORDS_MISSING_VALUES}"
+    )
+    nuget_internal_helper_error_if_empty("${NUARG_AUTOPKG_FILEPATH}" "You must provide a filepath to a .autopkg file as a AUTOPKG_FILEPATH argument.")
+    # Actual functionality
+    nuget_internal_pack_autopkg("${NUARG_AUTOPKG_FILEPATH}")
 endfunction()

--- a/cmake/internal/NuGetPack.nupkg.cmake
+++ b/cmake/internal/NuGetPack.nupkg.cmake
@@ -31,6 +31,26 @@ function(nuget_internal_pack NUSPEC_FILEPATH OUTPUT_DIRECTORY VERSION_OVERRIDE)
 endfunction()
 
 ## Internal.
+function(nuget_internal_pack_autopkg AUTOPKG_FILEPATH)
+    # Execute pack
+    execute_process(
+        COMMAND powershell -command "Write-NuGetPackage ${AUTOPKG_FILEPATH}"
+        ERROR_VARIABLE
+            NUGET_PACK_ERROR_VAR
+        RESULT_VARIABLE
+            NUGET_PACK_RESULT_VAR
+    )
+    nuget_internal_helper_error_if_not_empty(
+        "${NUGET_PACK_ERROR_VAR}"
+        "Running powershell -command \"Write-NuGetPackage ${AUTOPKG_FILEPATH}\" encountered some errors: "
+    )
+
+    if(NOT ${NUGET_PACK_RESULT_VAR} EQUAL 0)
+        message(FATAL_ERROR "powershell -command \"Write-NuGetPackage ${AUTOPKG_FILEPATH}\" returned with: \"${NUGET_PACK_RESULT_VAR}\"")
+    endif()
+endfunction()
+
+## Internal.
 function(nuget_internal_pack_install
     PACKAGE_ID
     PACKAGE_VERSION

--- a/tests/write_autopkg_nested/CMakeLists.txt
+++ b/tests/write_autopkg_nested/CMakeLists.txt
@@ -1,0 +1,150 @@
+set(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
+include("${PROJECT_ROOT}/cmake/NuGetTools.cmake")
+include(GNUInstallDirs)
+
+## CMake setup
+cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
+project(write_autopkg_nested LANGUAGES C CXX VERSION 1.2.3)
+set(CMAKE_C_COMPILER "")
+
+## NuGet setup: call it only once before any other nuget_* calls.
+nuget_initialize()
+
+## Import CMake exports of icu/flatbuffers from NuGet package exported from Vcpkg
+# Please note that strictly speaking this is not the proper way of using packages exported from Vcpkg. The reason this works:
+# 1) The vcpkg.cmake toolchain file (that we do not use here) does not contain any tricky settings regarding icu/flatbuffers.
+# 2) Icu/flatbuffers comes with proper CMake export files that we can simply directly use from the NuGet package (see CMAKE_PREFIX_PATHS below).
+# See https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure for determining a good CMAKE_PREFIX_PATHS value.
+nuget_add_dependencies(
+    PACKAGE flatbuffers.x64-windows.vcpkg-export VERSION 1.11.0-1 CMAKE_PREFIX_PATHS installed/x64-windows
+    PACKAGE icu.x64-windows.vcpkg-export PUBLIC VERSION 65.1.0-2 CMAKE_PREFIX_PATHS installed/x64-windows
+)
+# You can create above icu NuGet package by e.g. (assuming you are at VCPKG_ROOT):
+# 1) $ vcpkg install icu:x64-windows
+# 2) $ vcpkg export icu:x64-windows --nuget --nuget-version=65.1.0-2 --nuget-id=icu.x64-windows.vcpkg-export
+# 3) $ nuget add icu.x64-windows.vcpkg-export.65.1.0-2.nupkg -Source "%USERPROFILE%/.nuget/repository"
+
+## Find external dependencies
+# Business as usual from this point on. The above nuget_add_dependencies() takes care of setting the CMAKE_PREFIX_PATH.
+find_package(ICU REQUIRED COMPONENTS data uc io)
+# Only for flatbuffers::flatc and INTERFACE_INCLUDE_DIRECTORIES, flatbuffers.lib not needed.
+find_package(Flatbuffers CONFIG REQUIRED)
+get_target_property(FLATBUFFERS_INTERFACE_INCLUDE_DIRECTORIES flatbuffers::flatbuffers INTERFACE_INCLUDE_DIRECTORIES)
+
+## Generated sources
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/monster.h"
+    COMMAND flatbuffers::flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}/generated" "${CMAKE_CURRENT_SOURCE_DIR}/monster.fbs"
+    # From https://github.com/google/flatbuffers/blob/3ff6cdf49181061bd545bcd3a2a292bca3e8ef6b/samples/monster.fbs
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/monster.fbs"
+)
+add_custom_target(GeneratedFilesInternal DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/generated/monster.h")
+add_library(GeneratedFiles INTERFACE)
+# Not to be exported. This target is for internal use only, i.e. only other internal targets can use this interface include.
+target_include_directories(GeneratedFiles INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/generated")
+add_dependencies(GeneratedFiles GeneratedFilesInternal)
+
+## Create executable
+# From "Examining UTF-8 code units" of https://begriffs.com/posts/2019-05-23-unicode-icu.html#icu-example-programs
+# Test: echo "résumé façade" | ./nomarks
+# From https://github.com/google/flatbuffers/blob/42c08cbca601688af921eaa9384844a632e2cde8/samples/sample_binary.cpp
+add_library(WriteAutopkgNested SHARED nomarks.c sample_binary.cpp calculate.c calculate.h)
+# This is needed to build the library and export methods.
+target_compile_definitions(WriteAutopkgNested PRIVATE CALCULATE_BUILD)
+# TODO: These does not seem to link against the "icu*d65.dll" icu libraries in Debug mode (a "d" is appended just before the version number).
+target_link_libraries(WriteAutopkgNested PRIVATE ICU::data ICU::uc ICU::io GeneratedFiles)
+target_include_directories(WriteAutopkgNested PRIVATE "${FLATBUFFERS_INTERFACE_INCLUDE_DIRECTORIES}") # Only need flatbuffers/flatbuffers.h
+
+## Install the executable
+install(TARGETS WriteAutopkgNested
+    EXPORT WriteAutopkgNestedExport
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+    LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+)
+
+## Install .dlls the brute force way
+nuget_get_installed_dependencies_dirs(DEPENDENCIES_DIRS)
+foreach(PACKAGE_DIR IN LISTS DEPENDENCIES_DIRS)
+    install(
+        DIRECTORY "${PACKAGE_DIR}/installed/x64-windows/bin/"
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+        CONFIGURATIONS Release
+        # Note: empty folders are copied: https://gitlab.kitware.com/cmake/cmake/issues/17122
+        FILES_MATCHING
+            PATTERN "*.dll"
+            PATTERN "*.pdb"
+    )
+    install(
+        DIRECTORY "${PACKAGE_DIR}/installed/x64-windows/debug/bin/"
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+        CONFIGURATIONS Debug
+        # Note: empty folders are copied: https://gitlab.kitware.com/cmake/cmake/issues/17122
+        FILES_MATCHING
+            PATTERN "*.dll"
+            PATTERN "*.pdb"
+    )
+endforeach()
+
+## Installation of CMake Export Files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/WriteAutopkgNestedConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgNestedConfig.cmake"
+    INSTALL_DESTINATION cmake
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgNestedConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgNestedConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgNestedConfigVersion.cmake"
+    DESTINATION cmake
+)
+install(EXPORT WriteAutopkgNestedExport
+    FILE WriteAutopkgNestedTargets.cmake
+    NAMESPACE WriteAutopkgNested::
+    DESTINATION cmake
+)
+
+# Get the build architecture from the linker flags
+string(REGEX MATCH "/machine:.[(A-z)|(a-z)|(0-9)]*" ARCHITECTURE ${CMAKE_EXE_LINKER_FLAGS})
+string(REPLACE "/machine:" "" ARCHITECTURE ${ARCHITECTURE})
+
+## Write .autopkg file(s)
+nuget_generate_autopkg_files(
+    ## CMake-specific arguments section
+    CMAKE_OUTPUT_DIR ${CMAKE_BINARY_DIR}/CMakeNuGetTools # Optional: defaults to ${CMAKE_BINARY_DIR}/CMakeNuGetTools/autopkg
+    CMAKE_ARCHITECTURE ${ARCHITECTURE}
+    CMAKE_PLATFORMTOOLSET ${CMAKE_VS_PLATFORM_TOOLSET}
+    CMAKE_CONFIGURATIONS Release Debug                   # Optional: defaults to no restrictions given
+    ## Autopkg-related section below
+    NUSPEC
+        ## Required elements
+        PACKAGE ${PROJECT_NAME}
+        VERSION ${PROJECT_VERSION}
+        TITLE ${PROJECT_NAME}
+        DESCRIPTION "It's *the* package."
+        AUTHORS katusk cmake CMakeNuGetTools
+        OWNERS "katusk"
+        ## Optional elements
+        LICENSE_URL http://github.com/katusk
+        PROJECT_URL https://github.com/katusk
+        # ICON fake.png
+        SUMMARY "It's *the* package."
+        RELEASE_NOTES "No release notes yet."
+        COPYRIGHT katusk
+        TAGS "tag1;tag2"
+        ## Collection elements
+        ## Currently only DEPENDENCIES which is automatically generated based on nuget_add_dependencies() calls.
+    ## FILES node: required by our CMake implementation
+    FILES
+        INCLUDES
+            FILE_INCLUDE_DEST "\${d_include}/mylib"
+            FILE_INCLUDE_SRC "**/*.h"
+        OUTPUTS
+            FILE_BIN_SRC "$<TARGET_FILE_NAME:WriteAutopkgNested>"
+            FILE_LIB_SRC "$<TARGET_LINKER_FILE_NAME:WriteAutopkgNested>"
+            # Only in Debug mode: .pdb file
+            CMAKE_CONDITIONAL_SECTION $<CONFIG:Debug>
+                FILE_SYMBOLS_SRC "$<TARGET_PDB_FILE_NAME:WriteAutopkgNested>"
+)

--- a/tests/write_autopkg_nested/CMakeSettings.json
+++ b/tests/write_autopkg_nested/CMakeSettings.json
@@ -1,0 +1,45 @@
+{
+    "environments": [
+        {
+            "BuildRoot": "${projectDir}\\..\\..\\build",
+            "InstallRoot": "${projectDir}\\..\\..\\install",
+            "PackagesRoot": "${projectDir}\\..\\..\\packages",
+            "ProjectName": "write_autopkg_nested"
+        }
+    ],
+
+    "configurations": [
+        {
+            "configurationType": "Debug",
+            "name": "x64-windows\\${configurationType}",
+            "generator": "Visual Studio 16 2019",
+            "architecture": "x64",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "cmakeCommandArgs": "--trace-expand",
+            "buildCommandArgs": "/v:normal /m /p:CL_MPCount=8",
+            "ctestCommandArgs": "",
+            "variables": [
+                { "name": "NUGET_COMMAND", "value": "nuget" },
+                { "name": "NUGET_PACKAGES_DIR", "value": "${env.PackagesRoot}" }
+            ]
+        },
+        {
+            "configurationType": "Release",
+            "name": "x64-windows\\${configurationType}",
+            "generator": "Visual Studio 16 2019",
+            "architecture": "x64",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "cmakeCommandArgs": "--trace-expand",
+            "buildCommandArgs": "/v:normal /m /p:CL_MPCount=8",
+            "ctestCommandArgs": "",
+            "variables": [
+                { "name": "NUGET_COMMAND", "value": "nuget" },
+                { "name": "NUGET_PACKAGES_DIR", "value": "${env.PackagesRoot}" }
+            ]
+        }
+    ]
+}

--- a/tests/write_autopkg_nested/CMakeSettings.json
+++ b/tests/write_autopkg_nested/CMakeSettings.json
@@ -12,8 +12,7 @@
         {
             "configurationType": "Debug",
             "name": "x64-windows\\${configurationType}",
-            "generator": "Visual Studio 16 2019",
-            "architecture": "x64",
+            "generator": "Visual Studio 15 2017 Win64",
             "inheritEnvironments": [ "msvc_x64_x64" ],
             "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
             "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",
@@ -28,8 +27,7 @@
         {
             "configurationType": "Release",
             "name": "x64-windows\\${configurationType}",
-            "generator": "Visual Studio 16 2019",
-            "architecture": "x64",
+            "generator": "Visual Studio 15 2017 Win64",
             "inheritEnvironments": [ "msvc_x64_x64" ],
             "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
             "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",

--- a/tests/write_autopkg_nested/calculate.c
+++ b/tests/write_autopkg_nested/calculate.c
@@ -1,0 +1,6 @@
+#include "calculate.h"
+
+CALCULATE_EXPORT int Add(int a, int b)
+{
+    return a + b;
+}

--- a/tests/write_autopkg_nested/calculate.h
+++ b/tests/write_autopkg_nested/calculate.h
@@ -1,0 +1,9 @@
+#if defined(CALCULATE_BUILD)
+#   pragma message("Build library and export stuff")
+#   define CALCULATE_EXPORT __declspec (dllexport)
+#else
+#   pragma message("Use library and import stuff")
+#   define CALCULATE_EXPORT __declspec (dllimport)
+#endif
+
+CALCULATE_EXPORT int Add(int a, int b);

--- a/tests/write_autopkg_nested/cmake/WriteAutopkgNestedConfig.cmake.in
+++ b/tests/write_autopkg_nested/cmake/WriteAutopkgNestedConfig.cmake.in
@@ -1,0 +1,6 @@
+get_filename_component(WriteAutopkgNested_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(APPEND CMAKE_MODULE_PATH ${WriteAutopkgNested_CMAKE_DIR})
+if(NOT TARGET WriteAutopkgNested::WriteAutopkgNested)
+    include("${WriteAutopkgNested_CMAKE_DIR}/WriteAutopkgNestedTargets.cmake")
+endif()
+set(WriteAutopkgNested_LIBRARIES WriteAutopkgNested::WriteAutopkgNested)

--- a/tests/write_autopkg_nested/monster.fbs
+++ b/tests/write_autopkg_nested/monster.fbs
@@ -1,0 +1,33 @@
+// Example IDL file for our monster's schema.
+
+namespace MyGame.Sample;
+
+enum Color:byte { Red = 0, Green, Blue = 2 }
+
+union Equipment { Weapon } // Optionally add more tables.
+
+struct Vec3 {
+  x:float;
+  y:float;
+  z:float;
+}
+
+table Monster {
+  pos:Vec3;
+  mana:short = 150;
+  hp:short = 100;
+  name:string;
+  friendly:bool = false (deprecated);
+  inventory:[ubyte];
+  color:Color = Blue;
+  weapons:[Weapon];
+  equipped:Equipment;
+  path:[Vec3];
+}
+
+table Weapon {
+  name:string;
+  damage:short;
+}
+
+root_type Monster;

--- a/tests/write_autopkg_nested/nomarks.c
+++ b/tests/write_autopkg_nested/nomarks.c
@@ -1,0 +1,92 @@
+/*** nomarks.c ***/
+
+#include <stdlib.h>
+
+#include <unicode/uchar.h>
+#include <unicode/unorm2.h>
+#include <unicode/ustdio.h>
+#include <unicode/utf16.h>
+
+/* Limit to how many decomposed UTF-16 units a single
+ * codepoint will become in NFD. I don't know the
+ * correct value here so I chose a value that seems
+ * to be overkill */
+#define MAX_DECOMP_LEN 16
+
+// For sample_binary.cpp
+int f(int /*argc*/, const char * /*argv*/[]);
+
+int main(void)
+{
+    long i, n;
+    UChar32 c;
+    UFILE *in, *out;
+    UChar decomp[MAX_DECOMP_LEN];
+    UErrorCode status = U_ZERO_ERROR;
+    UNormalizer2 *norm;
+
+    out = u_get_stdout();
+
+    in = u_finit(stdin, NULL, NULL);
+    if (!in)
+    {
+        /* using stdio functions with stderr and ustdio
+         * with stdout. Mixing the two on a single file
+         * handle would probably be bad. */
+        fputs("Error opening stdin as UFILE\n", stderr);
+        return EXIT_FAILURE;
+    }
+
+    /* create a normalizer, in this case one going to NFD */
+    norm = (UNormalizer2 *)unorm2_getNFDInstance(&status);
+    if (U_FAILURE(status)) {
+        fprintf(stderr,
+            "unorm2_getNFDInstance(): %s\n",
+            u_errorName(status));
+        return EXIT_FAILURE;
+    }
+
+    /* consume input as UTF-32 units one by one */
+    while ((c = u_fgetcx(in)) != U_EOF)
+    {
+        /* Decompose c to isolate its n combining character
+         * codepoints. Saves them as UTF-16 code units.  FYI,
+         * this function ignores the type of "norm" and always
+         * denormalizes */
+        n = unorm2_getDecomposition(
+            norm, c, decomp, MAX_DECOMP_LEN, &status
+        );
+
+        if (U_FAILURE(status)) {
+            fprintf(stderr,
+                "unorm2_getDecomposition(): %s\n",
+                u_errorName(status));
+            u_fclose(in);
+            return EXIT_FAILURE;
+        }
+
+        /* if c does not decompose and is not itself
+         * a diacritical mark */
+        if (n < 0 && ublock_getCode(c) !=
+            UBLOCK_COMBINING_DIACRITICAL_MARKS)
+            u_fputc(c, out);
+
+        /* walk canonical decomposition, reuse c variable */
+        for (i = 0; i < n; )
+        {
+            /* the U16_NEXT macro iterates over UChar (aka
+             * UTF-16, advancing by one or two elements as
+             * needed to get a codepoint. It saves the result
+             * in UTF-32. The macro updates i and c. */
+            U16_NEXT(decomp, i, n, c);
+            /* output only if not combining diacritical */
+            if (ublock_getCode(c) !=
+                UBLOCK_COMBINING_DIACRITICAL_MARKS)
+                u_fputc(c, out);
+        }
+    }
+
+    u_fclose(in);
+    /* u_get_stdout() doesn't need to be u_fclose'd */
+    return EXIT_SUCCESS;
+}

--- a/tests/write_autopkg_nested/sample_binary.cpp
+++ b/tests/write_autopkg_nested/sample_binary.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monster_generated.h"  // Already includes "flatbuffers/flatbuffers.h".
+
+using namespace MyGame::Sample;
+
+// Example how to use FlatBuffers to create and read binary buffers.
+
+int f(int /*argc*/, const char * /*argv*/[]) {
+  // Build up a serialized buffer algorithmically:
+  flatbuffers::FlatBufferBuilder builder;
+
+  // First, lets serialize some weapons for the Monster: A 'sword' and an 'axe'.
+  auto weapon_one_name = builder.CreateString("Sword");
+  short weapon_one_damage = 3;
+
+  auto weapon_two_name = builder.CreateString("Axe");
+  short weapon_two_damage = 5;
+
+  // Use the `CreateWeapon` shortcut to create Weapons with all fields set.
+  auto sword = CreateWeapon(builder, weapon_one_name, weapon_one_damage);
+  auto axe = CreateWeapon(builder, weapon_two_name, weapon_two_damage);
+
+  // Create a FlatBuffer's `vector` from the `std::vector`.
+  std::vector<flatbuffers::Offset<Weapon>> weapons_vector;
+  weapons_vector.push_back(sword);
+  weapons_vector.push_back(axe);
+  auto weapons = builder.CreateVector(weapons_vector);
+
+  // Second, serialize the rest of the objects needed by the Monster.
+  auto position = Vec3(1.0f, 2.0f, 3.0f);
+
+  auto name = builder.CreateString("MyMonster");
+
+  unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  auto inventory = builder.CreateVector(inv_data, 10);
+
+  // Shortcut for creating monster with all fields set:
+  auto orc = CreateMonster(builder, &position, 150, 80, name, inventory,
+                           Color_Red, weapons, Equipment_Weapon, axe.Union());
+
+  builder.Finish(orc);  // Serialize the root of the object.
+
+  // We now have a FlatBuffer we can store on disk or send over a network.
+
+  // ** file/network code goes here :) **
+  // access builder.GetBufferPointer() for builder.GetSize() bytes
+
+  // Instead, we're going to access it right away (as if we just received it).
+
+  // Get access to the root:
+  auto monster = GetMonster(builder.GetBufferPointer());
+
+  // Get and test some scalar types from the FlatBuffer.
+  assert(monster->hp() == 80);
+  assert(monster->mana() == 150);  // default
+  assert(monster->name()->str() == "MyMonster");
+
+  // Get and test a field of the FlatBuffer's `struct`.
+  auto pos = monster->pos();
+  assert(pos);
+  assert(pos->z() == 3.0f);
+  (void)pos;
+
+  // Get a test an element from the `inventory` FlatBuffer's `vector`.
+  auto inv = monster->inventory();
+  assert(inv);
+  assert(inv->Get(9) == 9);
+  (void)inv;
+
+  // Get and test the `weapons` FlatBuffers's `vector`.
+  std::string expected_weapon_names[] = { "Sword", "Axe" };
+  short expected_weapon_damages[] = { 3, 5 };
+  auto weps = monster->weapons();
+  for (unsigned int i = 0; i < weps->size(); i++) {
+    assert(weps->Get(i)->name()->str() == expected_weapon_names[i]);
+    assert(weps->Get(i)->damage() == expected_weapon_damages[i]);
+  }
+  (void)expected_weapon_names;
+  (void)expected_weapon_damages;
+
+  // Get and test the `Equipment` union (`equipped` field).
+  assert(monster->equipped_type() == Equipment_Weapon);
+  auto equipped = static_cast<const Weapon *>(monster->equipped());
+  assert(equipped->name()->str() == "Axe");
+  assert(equipped->damage() == 5);
+  (void)equipped;
+
+  printf("The FlatBuffer was successfully created and verified!\n");
+  return 0;
+}

--- a/tests/write_autopkg_simple/CMakeLists.txt
+++ b/tests/write_autopkg_simple/CMakeLists.txt
@@ -1,0 +1,143 @@
+set(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
+include("${PROJECT_ROOT}/cmake/NuGetTools.cmake")
+include(GNUInstallDirs)
+
+## CMake setup
+cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
+project(write_autopkg_simple LANGUAGES CXX VERSION 1.2.3)
+set(CMAKE_C_COMPILER "")
+
+## NuGet setup: call it only once before any other nuget_* calls.
+nuget_initialize()
+
+## Import CMake exports of icu/flatbuffers from NuGet package exported from Vcpkg
+# Please note that strictly speaking this is not the proper way of using packages exported from Vcpkg. The reason this works:
+# 1) The vcpkg.cmake toolchain file (that we do not use here) does not contain any tricky settings regarding icu/flatbuffers.
+# 2) Icu/flatbuffers comes with proper CMake export files that we can simply directly use from the NuGet package (see CMAKE_PREFIX_PATHS below).
+# See https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure for determining a good CMAKE_PREFIX_PATHS value.
+nuget_add_dependencies(
+    PACKAGE flatbuffers.x64-windows.vcpkg-export VERSION 1.11.0-1 CMAKE_PREFIX_PATHS installed/x64-windows
+    PACKAGE icu.x64-windows.vcpkg-export PUBLIC VERSION 65.1.0-2 CMAKE_PREFIX_PATHS installed/x64-windows
+)
+# You can create above icu NuGet package by e.g. (assuming you are at VCPKG_ROOT):
+# 1) $ vcpkg install icu:x64-windows
+# 2) $ vcpkg export icu:x64-windows --nuget --nuget-version=65.1.0-2 --nuget-id=icu.x64-windows.vcpkg-export
+# 3) $ nuget add icu.x64-windows.vcpkg-export.65.1.0-2.nupkg -Source "%USERPROFILE%/.nuget/repository"
+
+## Find external dependencies
+# Business as usual from this point on. The above nuget_add_dependencies() takes care of setting the CMAKE_PREFIX_PATH.
+find_package(ICU REQUIRED COMPONENTS data uc io)
+# Only for flatbuffers::flatc and INTERFACE_INCLUDE_DIRECTORIES, flatbuffers.lib not needed.
+find_package(Flatbuffers CONFIG REQUIRED)
+get_target_property(FLATBUFFERS_INTERFACE_INCLUDE_DIRECTORIES flatbuffers::flatbuffers INTERFACE_INCLUDE_DIRECTORIES)
+
+## Generated sources
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/generated/monster.h"
+    COMMAND flatbuffers::flatc --cpp -o "${CMAKE_CURRENT_BINARY_DIR}/generated" "${CMAKE_CURRENT_SOURCE_DIR}/monster.fbs"
+    # From https://github.com/google/flatbuffers/blob/3ff6cdf49181061bd545bcd3a2a292bca3e8ef6b/samples/monster.fbs
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/monster.fbs"
+)
+add_custom_target(GeneratedFilesInternal DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/generated/monster.h")
+add_library(GeneratedFiles INTERFACE)
+# Not to be exported. This target is for internal use only, i.e. only other internal targets can use this interface include.
+target_include_directories(GeneratedFiles INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/generated")
+add_dependencies(GeneratedFiles GeneratedFilesInternal)
+
+## Create executable
+# From "Examining UTF-8 code units" of https://begriffs.com/posts/2019-05-23-unicode-icu.html#icu-example-programs
+# Test: echo "résumé façade" | ./nomarks
+# From https://github.com/google/flatbuffers/blob/42c08cbca601688af921eaa9384844a632e2cde8/samples/sample_binary.cpp
+add_library(WriteAutopkgSimple SHARED nomarks.c sample_binary.cpp)
+# TODO: These does not seem to link against the "icu*d65.dll" icu libraries in Debug mode (a "d" is appended just before the version number).
+target_link_libraries(WriteAutopkgSimple PRIVATE ICU::data ICU::uc ICU::io GeneratedFiles)
+target_include_directories(WriteAutopkgSimple PRIVATE "${FLATBUFFERS_INTERFACE_INCLUDE_DIRECTORIES}") # Only need flatbuffers/flatbuffers.h
+
+## Install the executable
+install(TARGETS WriteAutopkgSimple
+    EXPORT WriteAutopkgSimpleExport
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+    LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+)
+
+## Install .dlls the brute force way
+nuget_get_installed_dependencies_dirs(DEPENDENCIES_DIRS)
+foreach(PACKAGE_DIR IN LISTS DEPENDENCIES_DIRS)
+    install(
+        DIRECTORY "${PACKAGE_DIR}/installed/x64-windows/bin/"
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+        CONFIGURATIONS Release
+        # Note: empty folders are copied: https://gitlab.kitware.com/cmake/cmake/issues/17122
+        FILES_MATCHING
+            PATTERN "*.dll"
+            PATTERN "*.pdb"
+    )
+    install(
+        DIRECTORY "${PACKAGE_DIR}/installed/x64-windows/debug/bin/"
+        DESTINATION ${CMAKE_INSTALL_BINDIR}/$<CONFIG>
+        CONFIGURATIONS Debug
+        # Note: empty folders are copied: https://gitlab.kitware.com/cmake/cmake/issues/17122
+        FILES_MATCHING
+            PATTERN "*.dll"
+            PATTERN "*.pdb"
+    )
+endforeach()
+
+## Installation of CMake Export Files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(cmake/WriteAutopkgSimpleConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgSimpleConfig.cmake"
+    INSTALL_DESTINATION cmake
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgSimpleConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgSimpleConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/WriteAutopkgSimpleConfigVersion.cmake"
+    DESTINATION cmake
+)
+install(EXPORT WriteAutopkgSimpleExport
+    FILE WriteAutopkgSimpleTargets.cmake
+    NAMESPACE WriteAutopkgSimple::
+    DESTINATION cmake
+)
+
+# Get the build architecture from the linker flags
+string(REGEX MATCH "/machine:.[(A-z)|(a-z)|(0-9)]*" ARCHITECTURE ${CMAKE_EXE_LINKER_FLAGS})
+string(REPLACE "/machine:" "" ARCHITECTURE ${ARCHITECTURE})
+
+## Write .autopkg file(s)
+nuget_generate_autopkg_files(
+    ## CMake-specific arguments section
+    CMAKE_OUTPUT_DIR ${CMAKE_BINARY_DIR}/CMakeNuGetTools # Optional: defaults to ${CMAKE_BINARY_DIR}/CMakeNuGetTools/autopkg
+    CMAKE_ARCHITECTURE ${ARCHITECTURE}
+    CMAKE_PLATFORMTOOLSET ${CMAKE_VS_PLATFORM_TOOLSET}
+    CMAKE_CONFIGURATIONS Release Debug                   # Optional: defaults to no restrictions given
+    ## Autopkg-related section below
+    NUSPEC
+        ## Required elements
+        PACKAGE ${PROJECT_NAME}
+        VERSION ${PROJECT_VERSION}
+        TITLE ${PROJECT_NAME}
+        DESCRIPTION "It's *the* package."
+        AUTHORS katusk cmake CMakeNuGetTools
+        OWNERS "katusk"
+        ## Optional elements
+        LICENSE_URL http://github.com/katusk
+        PROJECT_URL https://github.com/katusk
+        # ICON fake.png
+        SUMMARY "It's *the* package."
+        RELEASE_NOTES "No release notes yet."
+        COPYRIGHT katusk
+        TAGS "tag1;tag2"
+        ## Collection elements
+        ## Currently only DEPENDENCIES which is automatically generated based on nuget_add_dependencies() calls.
+    ## FILES node: required by our CMake implementation
+    FILES
+        FILE_BIN_SRC "$<TARGET_FILE_NAME:WriteAutopkgSimple>"
+        # Only in Debug mode: .pdb file
+        CMAKE_CONDITIONAL_SECTION $<CONFIG:Debug>
+            FILE_SYMBOLS_SRC "$<TARGET_PDB_FILE_NAME:WriteAutopkgSimple>"
+)

--- a/tests/write_autopkg_simple/CMakeLists.txt
+++ b/tests/write_autopkg_simple/CMakeLists.txt
@@ -4,7 +4,7 @@ include(GNUInstallDirs)
 
 ## CMake setup
 cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
-project(write_autopkg_simple LANGUAGES CXX VERSION 1.2.3)
+project(write_autopkg_simple LANGUAGES C CXX VERSION 1.2.3)
 set(CMAKE_C_COMPILER "")
 
 ## NuGet setup: call it only once before any other nuget_* calls.
@@ -47,7 +47,9 @@ add_dependencies(GeneratedFiles GeneratedFilesInternal)
 # From "Examining UTF-8 code units" of https://begriffs.com/posts/2019-05-23-unicode-icu.html#icu-example-programs
 # Test: echo "résumé façade" | ./nomarks
 # From https://github.com/google/flatbuffers/blob/42c08cbca601688af921eaa9384844a632e2cde8/samples/sample_binary.cpp
-add_library(WriteAutopkgSimple SHARED nomarks.c sample_binary.cpp)
+add_library(WriteAutopkgSimple SHARED nomarks.c sample_binary.cpp calculate.c calculate.h)
+# This is needed to build the library and export methods.
+target_compile_definitions(WriteAutopkgSimple PRIVATE CALCULATE_BUILD)
 # TODO: These does not seem to link against the "icu*d65.dll" icu libraries in Debug mode (a "d" is appended just before the version number).
 target_link_libraries(WriteAutopkgSimple PRIVATE ICU::data ICU::uc ICU::io GeneratedFiles)
 target_include_directories(WriteAutopkgSimple PRIVATE "${FLATBUFFERS_INTERFACE_INCLUDE_DIRECTORIES}") # Only need flatbuffers/flatbuffers.h
@@ -136,8 +138,12 @@ nuget_generate_autopkg_files(
         ## Currently only DEPENDENCIES which is automatically generated based on nuget_add_dependencies() calls.
     ## FILES node: required by our CMake implementation
     FILES
-        FILE_BIN_SRC "$<TARGET_FILE_NAME:WriteAutopkgSimple>"
-        # Only in Debug mode: .pdb file
-        CMAKE_CONDITIONAL_SECTION $<CONFIG:Debug>
-            FILE_SYMBOLS_SRC "$<TARGET_PDB_FILE_NAME:WriteAutopkgSimple>"
+        INCLUDES
+            FILE_INCLUDE_SRC "**/*.h"
+        OUTPUTS
+            FILE_BIN_SRC "$<TARGET_FILE_NAME:WriteAutopkgSimple>"
+            FILE_LIB_SRC "$<TARGET_LINKER_FILE_NAME:WriteAutopkgSimple>"
+            # Only in Debug mode: .pdb file
+            CMAKE_CONDITIONAL_SECTION $<CONFIG:Debug>
+                FILE_SYMBOLS_SRC "$<TARGET_PDB_FILE_NAME:WriteAutopkgSimple>"
 )

--- a/tests/write_autopkg_simple/CMakeSettings.json
+++ b/tests/write_autopkg_simple/CMakeSettings.json
@@ -1,0 +1,43 @@
+{
+    "environments": [
+        {
+            "BuildRoot": "${projectDir}\\..\\..\\build",
+            "InstallRoot": "${projectDir}\\..\\..\\install",
+            "PackagesRoot": "${projectDir}\\..\\..\\packages",
+            "ProjectName": "write_autopkg_simple"
+        }
+    ],
+
+    "configurations": [
+        {
+            "configurationType": "Debug",
+            "name": "x64-windows\\${configurationType}",
+            "generator": "Visual Studio 15 2017 Win64",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "cmakeCommandArgs": "--trace-expand",
+            "buildCommandArgs": "/v:normal /m /p:CL_MPCount=8",
+            "ctestCommandArgs": "",
+            "variables": [
+                { "name": "NUGET_COMMAND", "value": "nuget" },
+                { "name": "NUGET_PACKAGES_DIR", "value": "${env.PackagesRoot}" }
+            ]
+        },
+        {
+            "configurationType": "Release",
+            "name": "x64-windows\\${configurationType}",
+            "generator": "Visual Studio 15 2017 Win64",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${env.BuildRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "installRoot": "${env.InstallRoot}\\vs2017\\${env.ProjectName}\\${name}",
+            "cmakeCommandArgs": "--trace-expand",
+            "buildCommandArgs": "/v:normal /m /p:CL_MPCount=8",
+            "ctestCommandArgs": "",
+            "variables": [
+                { "name": "NUGET_COMMAND", "value": "nuget" },
+                { "name": "NUGET_PACKAGES_DIR", "value": "${env.PackagesRoot}" }
+            ]
+        }
+    ]
+}

--- a/tests/write_autopkg_simple/calculate.c
+++ b/tests/write_autopkg_simple/calculate.c
@@ -1,0 +1,6 @@
+#include "calculate.h"
+
+CALCULATE_EXPORT int Add(int a, int b)
+{
+    return a + b;
+}

--- a/tests/write_autopkg_simple/calculate.h
+++ b/tests/write_autopkg_simple/calculate.h
@@ -1,0 +1,9 @@
+#if defined(CALCULATE_BUILD)
+#   pragma message("Build library and export stuff")
+#   define CALCULATE_EXPORT __declspec (dllexport)
+#else
+#   pragma message("Use library and import stuff")
+#   define CALCULATE_EXPORT __declspec (dllimport)
+#endif
+
+CALCULATE_EXPORT int Add(int a, int b);

--- a/tests/write_autopkg_simple/cmake/WriteAutopkgSimpleConfig.cmake.in
+++ b/tests/write_autopkg_simple/cmake/WriteAutopkgSimpleConfig.cmake.in
@@ -1,0 +1,6 @@
+get_filename_component(WriteAutopkgSimple_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+list(APPEND CMAKE_MODULE_PATH ${WriteAutopkgSimple_CMAKE_DIR})
+if(NOT TARGET WriteAutopkgSimple::WriteAutopkgSimple)
+    include("${WriteAutopkgSimple_CMAKE_DIR}/WriteAutopkgSimpleTargets.cmake")
+endif()
+set(WriteAutopkgSimple_LIBRARIES WriteAutopkgSimple::WriteAutopkgSimple)

--- a/tests/write_autopkg_simple/monster.fbs
+++ b/tests/write_autopkg_simple/monster.fbs
@@ -1,0 +1,33 @@
+// Example IDL file for our monster's schema.
+
+namespace MyGame.Sample;
+
+enum Color:byte { Red = 0, Green, Blue = 2 }
+
+union Equipment { Weapon } // Optionally add more tables.
+
+struct Vec3 {
+  x:float;
+  y:float;
+  z:float;
+}
+
+table Monster {
+  pos:Vec3;
+  mana:short = 150;
+  hp:short = 100;
+  name:string;
+  friendly:bool = false (deprecated);
+  inventory:[ubyte];
+  color:Color = Blue;
+  weapons:[Weapon];
+  equipped:Equipment;
+  path:[Vec3];
+}
+
+table Weapon {
+  name:string;
+  damage:short;
+}
+
+root_type Monster;

--- a/tests/write_autopkg_simple/nomarks.c
+++ b/tests/write_autopkg_simple/nomarks.c
@@ -1,0 +1,92 @@
+/*** nomarks.c ***/
+
+#include <stdlib.h>
+
+#include <unicode/uchar.h>
+#include <unicode/unorm2.h>
+#include <unicode/ustdio.h>
+#include <unicode/utf16.h>
+
+/* Limit to how many decomposed UTF-16 units a single
+ * codepoint will become in NFD. I don't know the
+ * correct value here so I chose a value that seems
+ * to be overkill */
+#define MAX_DECOMP_LEN 16
+
+// For sample_binary.cpp
+int f(int /*argc*/, const char * /*argv*/[]);
+
+int main(void)
+{
+    long i, n;
+    UChar32 c;
+    UFILE *in, *out;
+    UChar decomp[MAX_DECOMP_LEN];
+    UErrorCode status = U_ZERO_ERROR;
+    UNormalizer2 *norm;
+
+    out = u_get_stdout();
+
+    in = u_finit(stdin, NULL, NULL);
+    if (!in)
+    {
+        /* using stdio functions with stderr and ustdio
+         * with stdout. Mixing the two on a single file
+         * handle would probably be bad. */
+        fputs("Error opening stdin as UFILE\n", stderr);
+        return EXIT_FAILURE;
+    }
+
+    /* create a normalizer, in this case one going to NFD */
+    norm = (UNormalizer2 *)unorm2_getNFDInstance(&status);
+    if (U_FAILURE(status)) {
+        fprintf(stderr,
+            "unorm2_getNFDInstance(): %s\n",
+            u_errorName(status));
+        return EXIT_FAILURE;
+    }
+
+    /* consume input as UTF-32 units one by one */
+    while ((c = u_fgetcx(in)) != U_EOF)
+    {
+        /* Decompose c to isolate its n combining character
+         * codepoints. Saves them as UTF-16 code units.  FYI,
+         * this function ignores the type of "norm" and always
+         * denormalizes */
+        n = unorm2_getDecomposition(
+            norm, c, decomp, MAX_DECOMP_LEN, &status
+        );
+
+        if (U_FAILURE(status)) {
+            fprintf(stderr,
+                "unorm2_getDecomposition(): %s\n",
+                u_errorName(status));
+            u_fclose(in);
+            return EXIT_FAILURE;
+        }
+
+        /* if c does not decompose and is not itself
+         * a diacritical mark */
+        if (n < 0 && ublock_getCode(c) !=
+            UBLOCK_COMBINING_DIACRITICAL_MARKS)
+            u_fputc(c, out);
+
+        /* walk canonical decomposition, reuse c variable */
+        for (i = 0; i < n; )
+        {
+            /* the U16_NEXT macro iterates over UChar (aka
+             * UTF-16, advancing by one or two elements as
+             * needed to get a codepoint. It saves the result
+             * in UTF-32. The macro updates i and c. */
+            U16_NEXT(decomp, i, n, c);
+            /* output only if not combining diacritical */
+            if (ublock_getCode(c) !=
+                UBLOCK_COMBINING_DIACRITICAL_MARKS)
+                u_fputc(c, out);
+        }
+    }
+
+    u_fclose(in);
+    /* u_get_stdout() doesn't need to be u_fclose'd */
+    return EXIT_SUCCESS;
+}

--- a/tests/write_autopkg_simple/sample_binary.cpp
+++ b/tests/write_autopkg_simple/sample_binary.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "monster_generated.h"  // Already includes "flatbuffers/flatbuffers.h".
+
+using namespace MyGame::Sample;
+
+// Example how to use FlatBuffers to create and read binary buffers.
+
+int f(int /*argc*/, const char * /*argv*/[]) {
+  // Build up a serialized buffer algorithmically:
+  flatbuffers::FlatBufferBuilder builder;
+
+  // First, lets serialize some weapons for the Monster: A 'sword' and an 'axe'.
+  auto weapon_one_name = builder.CreateString("Sword");
+  short weapon_one_damage = 3;
+
+  auto weapon_two_name = builder.CreateString("Axe");
+  short weapon_two_damage = 5;
+
+  // Use the `CreateWeapon` shortcut to create Weapons with all fields set.
+  auto sword = CreateWeapon(builder, weapon_one_name, weapon_one_damage);
+  auto axe = CreateWeapon(builder, weapon_two_name, weapon_two_damage);
+
+  // Create a FlatBuffer's `vector` from the `std::vector`.
+  std::vector<flatbuffers::Offset<Weapon>> weapons_vector;
+  weapons_vector.push_back(sword);
+  weapons_vector.push_back(axe);
+  auto weapons = builder.CreateVector(weapons_vector);
+
+  // Second, serialize the rest of the objects needed by the Monster.
+  auto position = Vec3(1.0f, 2.0f, 3.0f);
+
+  auto name = builder.CreateString("MyMonster");
+
+  unsigned char inv_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+  auto inventory = builder.CreateVector(inv_data, 10);
+
+  // Shortcut for creating monster with all fields set:
+  auto orc = CreateMonster(builder, &position, 150, 80, name, inventory,
+                           Color_Red, weapons, Equipment_Weapon, axe.Union());
+
+  builder.Finish(orc);  // Serialize the root of the object.
+
+  // We now have a FlatBuffer we can store on disk or send over a network.
+
+  // ** file/network code goes here :) **
+  // access builder.GetBufferPointer() for builder.GetSize() bytes
+
+  // Instead, we're going to access it right away (as if we just received it).
+
+  // Get access to the root:
+  auto monster = GetMonster(builder.GetBufferPointer());
+
+  // Get and test some scalar types from the FlatBuffer.
+  assert(monster->hp() == 80);
+  assert(monster->mana() == 150);  // default
+  assert(monster->name()->str() == "MyMonster");
+
+  // Get and test a field of the FlatBuffer's `struct`.
+  auto pos = monster->pos();
+  assert(pos);
+  assert(pos->z() == 3.0f);
+  (void)pos;
+
+  // Get a test an element from the `inventory` FlatBuffer's `vector`.
+  auto inv = monster->inventory();
+  assert(inv);
+  assert(inv->Get(9) == 9);
+  (void)inv;
+
+  // Get and test the `weapons` FlatBuffers's `vector`.
+  std::string expected_weapon_names[] = { "Sword", "Axe" };
+  short expected_weapon_damages[] = { 3, 5 };
+  auto weps = monster->weapons();
+  for (unsigned int i = 0; i < weps->size(); i++) {
+    assert(weps->Get(i)->name()->str() == expected_weapon_names[i]);
+    assert(weps->Get(i)->damage() == expected_weapon_damages[i]);
+  }
+  (void)expected_weapon_names;
+  (void)expected_weapon_damages;
+
+  // Get and test the `Equipment` union (`equipped` field).
+  assert(monster->equipped_type() == Equipment_Weapon);
+  auto equipped = static_cast<const Weapon *>(monster->equipped());
+  assert(equipped->name()->str() == "Axe");
+  assert(equipped->damage() == 5);
+  (void)equipped;
+
+  printf("The FlatBuffer was successfully created and verified!\n");
+  return 0;
+}


### PR DESCRIPTION
Autopkg files can be packaged by PowerShell's CoApp Write-NuGetPackage command (http://coapp.org). This way .target files are created automatically that are used by Visual Studio to find headers, libraries and binaries when invoking a NuGet package.
### Added
The file NuGetPack.autopkg.cmake contains all internal methods to generate the autopkg files and is based on NuGetPack.nuspec.cmake.
### Changes
NuGetPack.cmake is updated with methods to generate and merge autopkg files.
The file NuGetPack.nupkg.cmake is updated and contains the actual pack command.