### PR TITLE
Expose NuGet's -ConfigFile flag as user-settable cache variable

### DIFF
--- a/cmake/NuGetTools.cmake
+++ b/cmake/NuGetTools.cmake
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
 ## User-settable cache variables
 set(NUGET_COMMAND "" CACHE STRING "NuGet executable used for package installs. Empty means NuGetTools is disabled. Deliberately not a FILEPATH cache variable: you can set it simply to \"nuget.exe\" if the executable is within your PATH environment.")
 set(NUGET_PACKAGES_DIR "${CMAKE_SOURCE_DIR}/packages" CACHE PATH "Path to the directory used by NuGet to store installed packages.")
+set(NUGET_CONFIG_FILE "" CACHE FILEPATH "The NuGet configuration file to apply. If not specified, %AppData%\\NuGet\\NuGet.Config (Windows), or ~/.nuget/NuGet/NuGet.Config or ~/.config/NuGet/NuGet.Config (Mac/Linux) is used.")
 
 ## Advanced cache variables
 option(NUGET_NO_CACHE "Advanced. Add -NoCache option to NuGet install commands: \"Disable using the machine cache as the first package source.\"" FALSE)

--- a/cmake/internal/NuGetImport.core.cmake
+++ b/cmake/internal/NuGetImport.core.cmake
@@ -86,6 +86,10 @@ function(nuget_internal_core_install
     if(NUGET_EXCLUDE_VERSION)
         set(NUGET_EXCLUDE_VERSION_OPTION "-ExcludeVersion")
     endif()
+    if(NUGET_CONFIG_FILE)
+        set(NUGET_CONFIG_FILE_OPTION -ConfigFile "${NUGET_CONFIG_FILE}")
+    endif()
+
     # Execute install
     #
     # NOTE. Output is not parsed for additionally installed dependencies. It does not worth
@@ -102,6 +106,7 @@ function(nuget_internal_core_install
             ${NUGET_INSTALL_DIRECT_DOWNLOAD_OPTION}
             ${NUGET_PACKAGE_SAVE_MODE_OPTION}
             ${NUGET_EXCLUDE_VERSION_OPTION}
+            ${NUGET_CONFIG_FILE_OPTION}
         ERROR_VARIABLE
             NUGET_INSTALL_ERROR_VAR
         RESULT_VARIABLE

--- a/cmake/internal/NuGetPack.nupkg.cmake
+++ b/cmake/internal/NuGetPack.nupkg.cmake
@@ -8,6 +8,9 @@ function(nuget_internal_pack NUSPEC_FILEPATH OUTPUT_DIRECTORY VERSION_OVERRIDE)
     if(NOT "${VERSION_OVERRIDE}" STREQUAL "")
         set(VERSION_OVERRIDE "-Version ${VERSION_OVERRIDE}")
     endif()
+    if(NUGET_CONFIG_FILE)
+        set(NUGET_CONFIG_FILE_OPTION -ConfigFile "${NUGET_CONFIG_FILE}")
+    endif()
     # Execute pack
     execute_process(
         COMMAND "${NUGET_COMMAND}" pack "${NUSPEC_FILEPATH}"
@@ -15,6 +18,7 @@ function(nuget_internal_pack NUSPEC_FILEPATH OUTPUT_DIRECTORY VERSION_OVERRIDE)
             ${VERSION_OVERRIDE}
             -NonInteractive
             -NoDefaultExcludes
+            ${NUGET_CONFIG_FILE_OPTION}
             # Consider -NoPackageAnalysis as option (default FALSE)
         ERROR_VARIABLE
             NUGET_PACK_ERROR_VAR
@@ -62,6 +66,10 @@ function(nuget_internal_pack_install
         "No NuGet executable was provided; this means NuGetTools should have been disabled, and "
         "we should not ever reach a call to nuget_internal_pack_install()."
     )
+    if(NUGET_CONFIG_FILE)
+        set(NUGET_CONFIG_FILE_OPTION -ConfigFile "${NUGET_CONFIG_FILE}")
+    endif()
+
     # Execute
     execute_process(
         COMMAND "${NUGET_COMMAND}" install ${PACKAGE_ID}
@@ -69,6 +77,7 @@ function(nuget_internal_pack_install
             -OutputDirectory "${OUTPUT_DIRECTORY}"
             -Source "${SOURCE}"
             -NonInteractive
+            ${NUGET_CONFIG_FILE_OPTION}
         ERROR_VARIABLE
             NUGET_INSTALL_ERROR_VAR
         RESULT_VARIABLE
@@ -97,12 +106,16 @@ function(nuget_internal_pack_push
     if(NOT "${API_KEY}" STREQUAL "")
         set(API_KEY -ApiKey "${API_KEY}")
     endif()
+    if(NUGET_CONFIG_FILE)
+        set(NUGET_CONFIG_FILE_OPTION -ConfigFile "${NUGET_CONFIG_FILE}")
+    endif()
     # Execute
     execute_process(
         COMMAND "${NUGET_COMMAND}" push "${PACKAGE_PATH}"
             ${API_KEY}
             -Source "${SOURCE}"
             -NonInteractive
+            ${NUGET_CONFIG_FILE_OPTION}
         ERROR_VARIABLE
             NUGET_INSTALL_ERROR_VAR
         RESULT_VARIABLE


### PR DESCRIPTION
NuGet's -Configfile flag enables custom config files. If not set, NuGet falls back on the default behaviour and utilizes the global config file as per NuGet's documentation. See https://learn.microsoft.com/en-us/nuget/reference/cli-reference/cli-ref-install 